### PR TITLE
Add SOC 2 compliance dashboard (bento-grid dark UI)

### DIFF
--- a/web-react/src/App.js
+++ b/web-react/src/App.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, memo } from "react";
 import { v4 as uuidv4 } from 'uuid';
 import History from "./History";
+import Soc2Dashboard from "./Soc2Dashboard";
 import NeuralBrain from "./NeuralBrain";
 import { db } from "./firebase";
 import { collection, doc, setDoc, addDoc, serverTimestamp, increment } from "firebase/firestore";
@@ -31,18 +32,20 @@ const darkCss = `
   @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
   *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
   :root {
-    --bg: #060A11; --bg2: #0A121C; --bg3: #0D1622; --panel: #0A121C;
-    --border: rgba(41,211,255,0.09); --border2: rgba(41,211,255,0.18);
-    --accent: #29D3FF; --accent2: #1FA8CC;
-    --accent-glow: rgba(41,211,255,0.16); --accent-dim: rgba(41,211,255,0.08);
+    --bg: #0A0A0C; --bg2: #111113; --bg3: #17171A; --panel: #141416;
+    --border: rgba(255,255,255,0.06); --border2: rgba(255,255,255,0.12);
+    --accent: #4DD8E8; --accent2: #35B3C2;
+    --accent-glow: rgba(77,216,232,0.16); --accent-dim: rgba(77,216,232,0.08);
     --green: #22D97A; --green-dim: rgba(34,217,122,0.09);
     --red: #E15554; --red-dim: rgba(225,85,84,0.09);
-    --orange: #F0A857; --orange-dim: rgba(240,168,87,0.09);
+    --orange: #E8B84D; --orange-dim: rgba(232,184,77,0.09);
     --purple: #8B7CFF; --purple-dim: rgba(139,124,255,0.09);
-    --text: #F2F6FA; --text-mid: #8FA3B5; --text-dim: #4C6478;
+    --magenta: #C93DE0; --magenta-dim: rgba(201,61,224,0.1);
+    --text: #F2F2F4; --text-mid: #9A9AA2; --text-dim: #5A5A62;
     --mono: 'IBM Plex Mono', monospace; --sans: 'Inter', sans-serif; --display: 'Space Grotesk', sans-serif;
-    --scroll-btn-bg: rgba(41,211,255,0.16); --scroll-btn-border: rgba(41,211,255,0.4); --scroll-btn-color: #29D3FF;
-    --char-ok: #8FA3B5; --char-warn: #F0A857; --char-over: #E15554;
+    --scroll-btn-bg: rgba(77,216,232,0.16); --scroll-btn-border: rgba(77,216,232,0.4); --scroll-btn-color: #4DD8E8;
+    --char-ok: #9A9AA2; --char-warn: #E8B84D; --char-over: #E15554;
+    --radius: 18px; --radius-sm: 12px;
   }
 `;
 
@@ -154,7 +157,7 @@ const sharedCss = `
 
   /* ===== CHAT ===== */
   .chat-col { display: flex; flex-direction: column; overflow: hidden; position: relative;
-    background-image: linear-gradient(180deg, rgba(6,10,17,0.93) 0%, rgba(6,10,17,0.88) 60%, rgba(6,10,17,0.96) 100%),
+    background-image: linear-gradient(180deg, rgba(10,10,12,0.93) 0%, rgba(10,10,12,0.88) 60%, rgba(10,10,12,0.96) 100%),
       url('https://images.unsplash.com/photo-1770249196589-36453bf42a4b?fm=jpg&q=80&w=2000&auto=format&fit=crop');
     background-size: cover; background-position: center 25%; background-attachment: fixed; }
   .chat-header { display: flex; align-items: center; gap: 14px; padding: 0 28px; height: 68px; flex-shrink: 0; background: var(--panel); border-bottom: 1px solid var(--border); }
@@ -261,6 +264,43 @@ const sharedCss = `
   .top-ip-bar { flex: 1; height: 6px; background: var(--bg3); border-radius: 4px; overflow: hidden; }
   .top-ip-fill { height: 100%; background: linear-gradient(90deg, var(--accent), var(--purple)); border-radius: 4px; }
   .top-ip-count { font-family: var(--mono); font-size: 10px; color: var(--text-dim); min-width: 30px; text-align: right; }
+
+  /* ===== SOC 2 COMPLIANCE DASHBOARD (bento grid) ===== */
+  .bento-card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); padding: 20px; position: relative; overflow: hidden; }
+  .bento-card-title { font-family: var(--sans); font-size: 16px; font-weight: 700; color: var(--text); }
+  .bento-card-sub { font-family: var(--sans); font-size: 12px; color: var(--text-mid); margin-top: 2px; }
+  .bento-eyebrow { font-family: var(--mono); font-size: 9px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 10px; }
+  .bento-pill { display: inline-flex; align-items: center; gap: 7px; padding: 9px 18px; border-radius: 30px; background: linear-gradient(135deg, var(--accent), var(--magenta)); color: #060608; font-family: var(--sans); font-size: 12px; font-weight: 700; border: none; cursor: pointer; transition: transform 0.15s, box-shadow 0.15s; box-shadow: 0 6px 20px -6px var(--accent-glow); }
+  .bento-pill:hover { transform: translateY(-1px); box-shadow: 0 8px 24px -6px var(--accent-glow); }
+  .bento-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
+  .bento-dot.critical { background: var(--red); box-shadow: 0 0 6px var(--red); }
+  .bento-dot.elevated { background: var(--orange); box-shadow: 0 0 6px var(--orange); }
+  .bento-dot.informational { background: var(--green); box-shadow: 0 0 6px var(--green); }
+  .bento-widget { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; cursor: pointer; transition: border-color 0.15s, transform 0.15s; text-align: center; }
+  .bento-widget:hover { border-color: var(--border2); transform: translateY(-2px); }
+  .bento-widget.active { border-color: var(--accent); background: var(--accent-dim); }
+  .bento-widget-icon { width: 34px; height: 34px; display: flex; align-items: center; justify-content: center; color: var(--accent); }
+  .bento-widget-label { font-family: var(--sans); font-size: 12px; color: var(--text-mid); }
+  .bento-table { width: 100%; border-collapse: collapse; font-family: var(--sans); font-size: 13px; }
+  .bento-table th { text-align: left; padding: 8px 8px; color: var(--text-dim); font-family: var(--mono); font-size: 9px; letter-spacing: 1.2px; text-transform: uppercase; font-weight: 600; border-bottom: 1px solid var(--border); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .bento-table td { padding: 8px; border-bottom: 1px solid var(--border); color: var(--text-mid); font-size: 12.5px; }
+  .bento-table tr:last-child td { border-bottom: none; }
+  .bento-table tr:hover td { color: var(--text); }
+  .bento-see-all { font-family: var(--sans); font-size: 11px; font-weight: 600; color: var(--accent); background: none; border: none; cursor: pointer; }
+  .bento-heat-row { display: grid; grid-template-columns: 28px repeat(24, 1fr); gap: 2px; align-items: center; }
+  .bento-heat-cell { aspect-ratio: 1; border-radius: 3px; }
+  .bento-heat-label { font-family: var(--mono); font-size: 8px; color: var(--text-dim); }
+  .balance-row { display: grid; gap: 0; }
+  .balance-card { padding: 0 18px; border-left: 1px solid var(--border); display: flex; flex-direction: column; gap: 6px; }
+  .balance-card:first-child { padding-left: 0; border-left: none; }
+  .balance-label { font-family: var(--mono); font-size: 9px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--text-dim); }
+  .balance-value { font-family: var(--display); font-size: 26px; font-weight: 700; color: var(--text); line-height: 1; }
+  .balance-delta { font-family: var(--sans); font-size: 11px; font-weight: 600; }
+  .balance-delta.up { color: var(--green); }
+  .balance-delta.down { color: var(--red); }
+  .lollipop-col { display: flex; flex-direction: column; align-items: center; gap: 6px; flex: 1; }
+  .lollipop-stem { width: 3px; border-radius: 2px; background: var(--border2); position: relative; }
+  .lollipop-dot { width: 10px; height: 10px; border-radius: 50%; margin-top: -5px; }
 `;
 function SimpleExplain({ text }) {
   const [open, setOpen]       = useState(false);
@@ -438,171 +478,6 @@ function SiraMessage({ text, modelChip }) {
     </div>
   );
 }
-
-const AnalyticsPage = memo(function AnalyticsPage({ stats }) {
-  const [topIPs, setTopIPs] = useState([]);
-  const [timeline, setTimeline]   = useState([]);
-  const hourChartRef              = useRef(null);
-  const typeChartRef              = useRef(null);
-  const hourChartInstance         = useRef(null);
-  const typeChartInstance         = useRef(null);
-
-  useEffect(() => {
-    fetch(`${FLASK_URL}/top-ips?limit=10`).then(r=>r.json()).then(data=>setTopIPs(Array.isArray(data)?data:[])).catch(()=>{});
-    fetch(`${FLASK_URL}/timeline`).then(r=>r.json()).then(setTimeline).catch(()=>{});
-  }, []);
-
-  useEffect(() => {
-    if (!timeline.length || !hourChartRef.current || !window.Chart) return;
-    if (hourChartInstance.current) hourChartInstance.current.destroy();
-    const hours = Array.from({length:24},(_,i)=>String(i).padStart(2,'0'));
-    const counts = hours.map(h => timeline.find(t=>t.hour===h)?.count || 0);
-    const max = Math.max(...counts) || 1;
-    hourChartInstance.current = new window.Chart(hourChartRef.current, {
-      type:'bar',
-      data:{
-        labels: hours.map(h=>h+'h'),
-        datasets:[{
-          data: counts,
-          backgroundColor: counts.map(c => c===max?'#E15554':c>max*0.5?'#F0A857':'#29D3FF'),
-          borderRadius: 4,
-          borderSkipped: false
-        }]
-      },
-      options:{
-        responsive:true, maintainAspectRatio:false,
-        plugins:{legend:{display:false},tooltip:{
-          backgroundColor:'#0A121C',borderColor:'rgba(41,211,255,0.3)',borderWidth:1,
-          titleColor:'#29D3FF',bodyColor:'#8FA3B5',
-          titleFont:{family:'IBM Plex Mono',size:10},bodyFont:{family:'IBM Plex Mono',size:10},
-          callbacks:{title:i=>`Hour: ${i[0].label}`,body:i=>`Events: ${i[0].raw}`}
-        }},
-        scales:{
-          x:{grid:{color:'rgba(41,211,255,0.05)'},ticks:{color:'#4C6478',font:{family:'IBM Plex Mono',size:9},maxRotation:0},border:{color:'rgba(41,211,255,0.08)'}},
-          y:{grid:{color:'rgba(41,211,255,0.05)'},ticks:{color:'#4C6478',font:{family:'IBM Plex Mono',size:9}},border:{color:'rgba(41,211,255,0.08)'}}
-        }
-      }
-    });
-    return () => { if (hourChartInstance.current) hourChartInstance.current.destroy(); };
-  }, [timeline]);
-
-  useEffect(() => {
-    if (!stats || !typeChartRef.current || !window.Chart) return;
-    if (typeChartInstance.current) typeChartInstance.current.destroy();
-    const breakdown = stats.event_breakdown || {};
-    const labels = Object.keys(breakdown);
-    const data   = Object.values(breakdown);
-    const colors = { alert:'#E15554', dns:'#29D3FF', http:'#22D97A', tls:'#8B7CFF', flow:'#4C6478' };
-    typeChartInstance.current = new window.Chart(typeChartRef.current, {
-      type:'doughnut',
-      data:{
-        labels,
-        datasets:[{
-          data,
-          backgroundColor: labels.map(l=>colors[l]||'#8FA3B5'),
-          borderColor:'#0A121C',
-          borderWidth:3,
-          hoverOffset:6
-        }]
-      },
-      options:{
-        responsive:true, maintainAspectRatio:false, cutout:'70%',
-        plugins:{legend:{display:false},tooltip:{
-          backgroundColor:'#0A121C',borderColor:'rgba(41,211,255,0.3)',borderWidth:1,
-          titleColor:'#29D3FF',bodyColor:'#8FA3B5',
-          titleFont:{family:'IBM Plex Mono',size:10},bodyFont:{family:'IBM Plex Mono',size:10}
-        }}
-      }
-    });
-    return () => { if (typeChartInstance.current) typeChartInstance.current.destroy(); };
-  }, [stats]);
-
-  const breakdown = stats?.event_breakdown || {};
-  const breakdownTotal = Object.values(breakdown).reduce((a,b)=>a+b,0) || 1;
-  const typeColors = { alert:'#E15554', dns:'#29D3FF', http:'#22D97A', tls:'#8B7CFF', flow:'#4C6478' };
-  const maxCount = topIPs.length > 0 ? topIPs[0].count : 1;
-
-  return (
-    <div className="page">
-      <div className="page-title">Analytics</div>
-      <div className="page-sub">REAL-TIME EVENT ANALYSIS FROM YOUR LOGS</div>
-
-      <div style={{display:"grid",gridTemplateColumns:"repeat(4,1fr)",gap:12,marginBottom:22}}>
-        {[
-          {label:"TOTAL EVENTS", value:stats?.total_events||"--", color:"var(--accent)", sub:"from eve.json"},
-          {label:"ALERTS",       value:stats?.alert_count||"--",  color:"var(--red)",    sub:`${stats?.alert_count&&stats?.total_events?Math.round(stats.alert_count/stats.total_events*100):0}% of total`},
-          {label:"UNIQUE IPs",   value:stats?.unique_ips||"--",   color:"var(--orange)", sub:"threat actors"},
-          {label:"THREAT LEVEL", value:stats?.alert_count>10?"CRITICAL":stats?.alert_count>5?"HIGH":"ELEVATED", color:stats?.alert_count>10?"var(--red)":"var(--orange)", sub:"based on alerts"},
-        ].map((s,i)=>(
-          <div key={i} className="page-card" style={{padding:16}}>
-            <div style={{position:"absolute",top:0,left:0,right:0,height:1,background:`linear-gradient(90deg,transparent,${s.color},transparent)`}}/>
-            <div style={{fontFamily:"var(--mono)",fontSize:8,color:"var(--text-dim)",letterSpacing:1.5,marginBottom:9}}>{s.label}</div>
-            <div style={{fontFamily:"var(--display)",fontSize:s.label==="THREAT LEVEL"?15:28,fontWeight:700,color:s.color,lineHeight:1}}>{s.value}</div>
-            <div style={{fontFamily:"var(--mono)",fontSize:8,color:"var(--text-dim)",marginTop:5}}>{s.sub}</div>
-          </div>
-        ))}
-      </div>
-
-      <div className="page-card" style={{marginBottom:16}}>
-        <div style={{display:"flex",justifyContent:"space-between",alignItems:"center",marginBottom:18}}>
-          <div className="page-card-title" style={{marginBottom:0}}>EVENTS PER HOUR</div>
-          <div style={{display:"flex",gap:14}}>
-            {[["#E15554","Peak"],["#F0A857","High"],["#29D3FF","Normal"]].map(([color,label])=>(
-              <div key={label} style={{display:"flex",alignItems:"center",gap:5}}>
-                <div style={{width:8,height:8,borderRadius:3,background:color}}/>
-                <span style={{fontFamily:"var(--mono)",fontSize:8,color:"var(--text-dim)"}}>{label}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-        <div style={{position:"relative",height:200}}>
-          <canvas ref={hourChartRef} role="img" aria-label="Events per hour bar chart"/>
-        </div>
-      </div>
-
-      <div style={{display:"grid",gridTemplateColumns:"1fr 1fr",gap:16}}>
-
-        <div className="page-card">
-          <div className="page-card-title">EVENT TYPE BREAKDOWN</div>
-          <div style={{position:"relative",height:180}}>
-            <canvas ref={typeChartRef} role="img" aria-label="Event type donut chart"/>
-          </div>
-          <div style={{display:"flex",flexWrap:"wrap",gap:10,marginTop:16,paddingTop:14,borderTop:"1px solid var(--border)"}}>
-            {Object.entries(breakdown).map(([type,count])=>(
-              <div key={type} style={{display:"flex",alignItems:"center",gap:5}}>
-                <div style={{width:8,height:8,borderRadius:3,background:typeColors[type]||"#8FA3B5"}}/>
-                <span style={{fontFamily:"var(--mono)",fontSize:8,color:"var(--text-dim)",textTransform:"uppercase"}}>{type} {Math.round(count/breakdownTotal*100)}%</span>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div className="page-card">
-          <div className="page-card-title">TOP 10 ATTACKER IPs</div>
-          <div style={{display:"flex",flexDirection:"column",gap:11}}>
-            {topIPs.map((item,i)=>{
-              const color = i===0?"var(--red)":i<3?"var(--orange)":"var(--accent)";
-              return (
-                <div key={i}>
-                  <div style={{display:"flex",justifyContent:"space-between",marginBottom:4}}>
-                    <div style={{display:"flex",alignItems:"center",gap:8}}>
-                      <span style={{fontFamily:"var(--mono)",fontSize:8,color:"var(--text-dim)",minWidth:16}}>{i+1}.</span>
-                      <span style={{fontFamily:"var(--mono)",fontSize:10,color}}>{item.ip}</span>
-                    </div>
-                    <span style={{fontFamily:"var(--mono)",fontSize:9,color:"var(--text-dim)"}}>{item.count} hits</span>
-                  </div>
-                  <div className="top-ip-bar">
-                    <div className="top-ip-fill" style={{width:`${(item.count/maxCount)*100}%`,background:color,transition:"width 0.5s"}}/>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-});
 
 const InvestigationPage = memo(function InvestigationPage({ onAskSira }) {
   const [logs, setLogs]                     = useState([]);
@@ -1424,7 +1299,10 @@ setLoading(false);
         </aside>
 
         <div style={{display:page==="analytics"?"flex":"none",flex:1,overflow:"hidden"}}>
-          <AnalyticsPage stats={stats}/>
+          <Soc2Dashboard
+            onAskSira={(q)=>{setPage("dashboard");setTimeout(()=>sendMessage(q),300);}}
+            onSeeFindings={()=>setPage("investigation")}
+          />
         </div>
         <div style={{display:page==="investigation"?"flex":"none",flex:1,overflow:"hidden"}}>
           <InvestigationPage onAskSira={(q)=>{setPage("dashboard");setTimeout(()=>sendMessage(q),300);}}/>

--- a/web-react/src/Soc2Dashboard.js
+++ b/web-react/src/Soc2Dashboard.js
@@ -1,0 +1,332 @@
+import { useState, useEffect, useRef, useMemo, memo } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
+import { MeshDistortMaterial, Sphere } from "@react-three/drei";
+import ThreatMap from "./ThreatMap";
+
+const FLASK_URL = "http://localhost:5000";
+
+const TSC_ORDER = ["security", "availability", "confidentiality", "processing_integrity", "privacy"];
+const TSC_COLORS = {
+  security: "#4DD8E8",
+  availability: "#22D97A",
+  confidentiality: "#8B7CFF",
+  processing_integrity: "#E8B84D",
+  privacy: "#C93DE0",
+};
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const SEVERITY_LABEL = { critical: "Critical", elevated: "Elevated", informational: "Informational" };
+
+function IconTrend() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="3 17 9 11 13 15 21 6" /><polyline points="14 6 21 6 21 13" />
+    </svg>
+  );
+}
+function IconCoverage() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-11V5l-8-3-8 3v6c0 7 8 11 8 11z" />
+    </svg>
+  );
+}
+function IconTable() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="16" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="9" y1="10" x2="9" y2="20" />
+    </svg>
+  );
+}
+function IconGrid() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="3" y="14" width="7" height="7" /><rect x="14" y="14" width="7" height="7" />
+    </svg>
+  );
+}
+function IconSparkle() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2l1.9 5.9L20 10l-6.1 2.1L12 18l-1.9-5.9L4 10l6.1-2.1L12 2z" />
+    </svg>
+  );
+}
+
+function BlobMesh() {
+  const meshRef = useRef();
+  useFrame((_, delta) => { if (meshRef.current) meshRef.current.rotation.y += delta * 0.25; });
+  return (
+    <Sphere ref={meshRef} args={[1.15, 128, 128]}>
+      <MeshDistortMaterial color="#8B7CFF" attach="material" distort={0.45} speed={1.6} roughness={0.15} metalness={0.75} />
+    </Sphere>
+  );
+}
+
+function HeroBlob() {
+  return (
+    <Canvas camera={{ position: [0, 0, 3] }} gl={{ antialias: true, alpha: true }}>
+      <ambientLight intensity={0.7} />
+      <pointLight position={[3, 3, 3]} intensity={45} color="#4DD8E8" />
+      <pointLight position={[-3, -2, 2]} intensity={35} color="#C93DE0" />
+      <pointLight position={[0, 3, -3]} intensity={25} color="#E8B84D" />
+      <BlobMesh />
+    </Canvas>
+  );
+}
+
+const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) {
+  const [overview, setOverview]   = useState(null);
+  const [findings, setFindings]   = useState([]);
+  const [heatmap, setHeatmap]     = useState({ cells: [], max: 0 });
+  const [trend, setTrend]         = useState([]);
+  const [activeWidget, setActiveWidget] = useState("trend");
+
+  const trendChartRef      = useRef(null);
+  const trendChartInstance = useRef(null);
+  const trendSectionRef    = useRef(null);
+  const coverageSectionRef = useRef(null);
+  const findingsSectionRef = useRef(null);
+  const heatmapSectionRef  = useRef(null);
+
+  useEffect(() => {
+    fetch(`${FLASK_URL}/compliance/overview`).then(r => r.json()).then(setOverview).catch(() => {});
+    fetch(`${FLASK_URL}/compliance/findings?limit=8`).then(r => r.json()).then(d => setFindings(Array.isArray(d) ? d : [])).catch(() => {});
+    fetch(`${FLASK_URL}/compliance/heatmap`).then(r => r.json()).then(d => setHeatmap(d || { cells: [], max: 0 })).catch(() => {});
+    fetch(`${FLASK_URL}/compliance/trend`).then(r => r.json()).then(d => setTrend(Array.isArray(d) ? d : [])).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!trend.length || !trendChartRef.current || !window.Chart) return;
+    if (trendChartInstance.current) trendChartInstance.current.destroy();
+    trendChartInstance.current = new window.Chart(trendChartRef.current, {
+      type: "line",
+      data: {
+        labels: trend.map(t => t.date),
+        datasets: [
+          {
+            label: "Compliance score",
+            data: trend.map(t => t.score),
+            borderColor: "#4DD8E8", backgroundColor: "rgba(77,216,232,0.12)",
+            tension: 0.4, fill: true, pointRadius: 3, pointBackgroundColor: "#4DD8E8",
+            yAxisID: "y",
+          },
+          {
+            label: "Alert volume",
+            data: trend.map(t => t.alerts),
+            borderColor: "#C93DE0", backgroundColor: "transparent",
+            tension: 0.4, fill: false, pointRadius: 3, pointBackgroundColor: "#C93DE0",
+            yAxisID: "y1",
+          },
+        ],
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        interaction: { mode: "index", intersect: false },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: "#141416", borderColor: "rgba(77,216,232,0.3)", borderWidth: 1,
+            titleColor: "#4DD8E8", bodyColor: "#9A9AA2",
+            titleFont: { family: "Inter", size: 11 }, bodyFont: { family: "IBM Plex Mono", size: 10 },
+          },
+        },
+        scales: {
+          x: { grid: { color: "rgba(255,255,255,0.04)", borderDash: [3, 4] }, ticks: { color: "#5A5A62", font: { family: "IBM Plex Mono", size: 9 } } },
+          y: { position: "left", grid: { color: "rgba(255,255,255,0.04)", borderDash: [3, 4] }, ticks: { color: "#5A5A62", font: { family: "IBM Plex Mono", size: 9 } }, min: 0, max: 100 },
+          y1: { position: "right", grid: { display: false }, ticks: { color: "#5A5A62", font: { family: "IBM Plex Mono", size: 9 } } },
+        },
+      },
+    });
+    return () => { if (trendChartInstance.current) trendChartInstance.current.destroy(); };
+  }, [trend]);
+
+  const heatGrid = useMemo(() => {
+    const byCell = {};
+    heatmap.cells.forEach(c => { byCell[`${c.weekday}-${c.hour}`] = c.count; });
+    return byCell;
+  }, [heatmap]);
+
+  const jumpTo = (widget, ref) => { setActiveWidget(widget); ref.current?.scrollIntoView({ behavior: "smooth", block: "start" }); };
+
+  const criteria = overview?.criteria || [];
+  const findingsRelative = (ts) => {
+    if (!ts) return "--";
+    const d = new Date(ts);
+    if (isNaN(d.getTime())) return ts.slice(5, 16).replace("T", " ");
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  };
+
+  return (
+    <div className="page" style={{ padding: 20 }}>
+      <div className="page-title">SOC 2 Compliance Dashboard</div>
+      <div className="page-sub">TRUST SERVICE CRITERIA — LIVE FROM SURICATA, ZEEK &amp; SENTINEL TELEMETRY</div>
+
+      {/* ── TOP ROW: hero + trend + widget switcher ── */}
+      <div style={{ display: "grid", gridTemplateColumns: "260px 1fr 220px", gap: 14, marginBottom: 14 }}>
+        <div className="bento-card" style={{ padding: 16, display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+          <div style={{ width: "100%", height: 150, borderRadius: 14, overflow: "hidden", background: "radial-gradient(circle at 50% 40%, rgba(139,124,255,0.18), transparent 70%)" }}>
+            <HeroBlob />
+          </div>
+          <button className="bento-pill" onClick={() => onAskSira && onAskSira("Give me a summary of our current SOC 2 compliance posture and any open findings.")}>
+            <IconSparkle /> AI analytics
+          </button>
+        </div>
+
+        <div className="bento-card" ref={trendSectionRef}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+            <div>
+              <div className="bento-card-title">Compliance Score Trend</div>
+              <div className="bento-card-sub">Daily score vs. alert volume, derived from live telemetry</div>
+            </div>
+            <div style={{ display: "flex", gap: 14 }}>
+              {[["#4DD8E8", "Score"], ["#C93DE0", "Alerts"]].map(([color, label]) => (
+                <div key={label} style={{ display: "flex", alignItems: "center", gap: 5 }}>
+                  <div style={{ width: 8, height: 8, borderRadius: "50%", background: color }} />
+                  <span style={{ fontFamily: "var(--sans)", fontSize: 11, color: "var(--text-mid)" }}>{label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div style={{ position: "relative", height: 190, marginTop: 14 }}>
+            <canvas ref={trendChartRef} role="img" aria-label="Compliance score trend line chart" />
+          </div>
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gridTemplateRows: "1fr 1fr", gap: 10 }}>
+          {[
+            { key: "trend",    icon: <IconTrend />,    label: "Score Trend",  ref: trendSectionRef },
+            { key: "coverage", icon: <IconCoverage />, label: "Coverage",     ref: coverageSectionRef },
+            { key: "findings", icon: <IconTable />,     label: "Findings",     ref: findingsSectionRef },
+            { key: "heatmap",  icon: <IconGrid />,      label: "Alert Heatmap", ref: heatmapSectionRef },
+          ].map(w => (
+            <div key={w.key} className={`bento-card bento-widget${activeWidget === w.key ? " active" : ""}`} onClick={() => jumpTo(w.key, w.ref)}>
+              <div className="bento-widget-icon">{w.icon}</div>
+              <div className="bento-widget-label">{w.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* ── MIDDLE ROW: findings / heatmap / map ── */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 14, marginBottom: 14 }}>
+        <div className="bento-card" ref={findingsSectionRef}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+            <div className="bento-card-title">Audit Findings</div>
+            <button className="bento-see-all" onClick={() => onSeeFindings && onSeeFindings()}>See all</button>
+          </div>
+          <div style={{ overflowX: "auto" }}>
+            <table className="bento-table" style={{ tableLayout: "fixed", width: "100%" }}>
+              <colgroup><col style={{ width: "42%" }} /><col style={{ width: "22%" }} /><col style={{ width: "20%" }} /><col style={{ width: "16%" }} /></colgroup>
+              <thead><tr><th>Signature</th><th>Source</th><th>Status</th><th>Time</th></tr></thead>
+              <tbody>
+                {findings.length === 0 && (
+                  <tr><td colSpan={4} style={{ color: "var(--text-dim)" }}>No open findings</td></tr>
+                )}
+                {findings.map(f => (
+                  <tr key={f.id}>
+                    <td style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={f.title}>{f.title}</td>
+                    <td style={{ fontFamily: "var(--mono)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.src_ip || "--"}</td>
+                    <td style={{ overflow: "hidden" }}>
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 5, whiteSpace: "nowrap" }}>
+                        <span className={`bento-dot ${f.severity}`} />
+                        {SEVERITY_LABEL[f.severity] || f.severity}
+                      </span>
+                    </td>
+                    <td style={{ fontFamily: "var(--mono)", fontSize: 10, whiteSpace: "nowrap" }}>{findingsRelative(f.detected_at)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="bento-card" ref={heatmapSectionRef}>
+          <div className="bento-card-title" style={{ marginBottom: 14 }}>Alert Heatmap</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {WEEKDAYS.map((day, wd) => (
+              <div key={day} className="bento-heat-row">
+                <span className="bento-heat-label">{day}</span>
+                {Array.from({ length: 24 }, (_, hr) => {
+                  const count = heatGrid[`${wd}-${hr}`] || 0;
+                  const intensity = heatmap.max ? count / heatmap.max : 0;
+                  return (
+                    <div
+                      key={hr}
+                      className="bento-heat-cell"
+                      title={`${day} ${hr}:00 — ${count} alerts`}
+                      style={{ background: count === 0 ? "var(--bg3)" : `rgba(77,216,232,${0.15 + intensity * 0.8})` }}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+          <div style={{ display: "flex", justifyContent: "space-between", marginTop: 8 }}>
+            <span className="bento-heat-label">00h</span><span className="bento-heat-label">12h</span><span className="bento-heat-label">23h</span>
+          </div>
+        </div>
+
+        <div className="bento-card" style={{ padding: 0, overflow: "hidden" }}>
+          <div style={{ position: "absolute", top: 16, left: 20, zIndex: 500 }}>
+            <div className="bento-card-title" style={{ fontSize: 14 }}>Incident Origins</div>
+          </div>
+          <div style={{ height: 320 }}>
+            <ThreatMap />
+          </div>
+        </div>
+      </div>
+
+      {/* ── BOTTOM ROW: control coverage lollipop + TSC balances ── */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1.6fr", gap: 14 }}>
+        <div className="bento-card" ref={coverageSectionRef}>
+          <div className="bento-card-title" style={{ marginBottom: 4 }}>Control Coverage by Criteria</div>
+          <div className="bento-card-sub" style={{ marginBottom: 18 }}>{overview?.controls_passing ?? "--"} / {overview?.controls_total ?? "--"} controls passing</div>
+          <div style={{ display: "flex", alignItems: "flex-end", height: 150, gap: 4 }}>
+            {TSC_ORDER.map(key => {
+              const c = criteria.find(x => x.key === key);
+              const score = c?.score ?? 0;
+              const color = TSC_COLORS[key];
+              return (
+                <div key={key} className="lollipop-col">
+                  <div className="lollipop-stem" style={{ height: `${Math.max(score, 4)}%`, background: `linear-gradient(180deg, transparent, ${color}66)` }}>
+                    <div className="lollipop-dot" style={{ background: color, boxShadow: `0 0 8px ${color}` }} />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div style={{ display: "flex", gap: 4, marginTop: 6 }}>
+            {TSC_ORDER.map(key => (
+              <div key={key} style={{ flex: 1, textAlign: "center", fontFamily: "var(--mono)", fontSize: 8, color: "var(--text-dim)", letterSpacing: 0.5 }}>
+                {(overview ? (criteria.find(x => x.key === key)?.score ?? 0) : "--")}%
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="bento-card">
+          <div className="bento-card-title" style={{ marginBottom: 16 }}>Trust Service Criteria Balances</div>
+          <div className="balance-row" style={{ gridTemplateColumns: `repeat(${TSC_ORDER.length}, 1fr)` }}>
+            {TSC_ORDER.map(key => {
+              const c = criteria.find(x => x.key === key);
+              const score = c?.score ?? 0;
+              const up = score >= 80;
+              return (
+                <div key={key} className="balance-card">
+                  <div className="balance-label">{c?.label || key}</div>
+                  <div className="balance-value">{overview ? `${score}%` : "--"}</div>
+                  <div className={`balance-delta ${up ? "up" : "down"}`}>
+                    {up ? "▲" : "▼"} {c ? `${c.controls_passing}/${c.controls_total} controls` : ""}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default Soc2Dashboard;

--- a/web/app.py
+++ b/web/app.py
@@ -9,6 +9,7 @@ from langchain_ollama import OllamaEmbeddings
 from langchain_chroma import Chroma
 from langchain_mistralai import ChatMistralAI
 from collections import Counter
+from datetime import datetime
 import sqlite3
 import json
 import os
@@ -1278,6 +1279,233 @@ def sentinel_config():
         json.dump(existing, f, indent=2)
 
     return jsonify({"message": "Sentinel server IP updated", "server": existing['server']})
+
+
+# ── SOC 2 COMPLIANCE DASHBOARD ────────────────────────────────────────────────
+# Controls are evaluated live against real telemetry (Suricata/Zeek events in
+# eve.json, Sentinel endpoint check-ins, and the LLM/vector-store health check)
+# rather than stored as opinions — there is no separate "compliance" data
+# source, so each control's pass/warn/fail is a heuristic read of the same
+# signals the rest of the app already collects.
+
+TSC_CATEGORIES = {
+    "security":              "Security",
+    "availability":          "Availability",
+    "confidentiality":       "Confidentiality",
+    "processing_integrity":  "Processing Integrity",
+    "privacy":               "Privacy",
+}
+
+def _log_date_hour(ts):
+    """Extract (YYYY-MM-DD, hour:int) from a Suricata ISO timestamp, or (None, None)."""
+    m = re.match(r'(\d{4}-\d{2}-\d{2})T(\d{2}):', ts or '')
+    if not m:
+        return None, None
+    return m.group(1), int(m.group(2))
+
+
+def _compliance_context():
+    logs = load_logs()
+    total_events = len(logs)
+    alert_events = [l for l in logs if l.get('event_type') == 'alert']
+    alert_count = len(alert_events)
+    tls_count = sum(1 for l in logs if l.get('event_type') == 'tls')
+    dns_count = sum(1 for l in logs if l.get('event_type') == 'dns')
+    unique_ips = len(set(l.get('src_ip') for l in logs if l.get('src_ip')))
+    critical_alerts = sum(1 for l in alert_events if l.get('alert', {}).get('severity') == 1)
+
+    try:
+        OllamaLLM(model="sira-model").invoke("ping")
+        ollama_ok = True
+    except Exception:
+        ollama_ok = False
+    try:
+        vectorstore.get(limit=1)
+        chroma_ok = True
+    except Exception:
+        chroma_ok = False
+
+    conn = get_db()
+    machines = conn.execute("SELECT * FROM sentinel_machines").fetchall()
+    user_count = conn.execute("SELECT COUNT(*) AS c FROM users").fetchone()["c"]
+    conn.close()
+
+    now = datetime.utcnow()
+    stale_machines = 0
+    flagged_machines = 0
+    for m in machines:
+        if m["alert"]:
+            flagged_machines += 1
+        try:
+            last_seen = datetime.fromisoformat((m["last_seen"] or "").replace("Z", ""))
+            if (now - last_seen).total_seconds() > 900:
+                stale_machines += 1
+        except ValueError:
+            stale_machines += 1
+
+    return {
+        "total_events": total_events,
+        "alert_count": alert_count,
+        "alert_ratio": (alert_count / total_events) if total_events else 0,
+        "tls_count": tls_count,
+        "dns_count": dns_count,
+        "dns_ratio": (dns_count / total_events) if total_events else 0,
+        "unique_ips": unique_ips,
+        "critical_alerts": critical_alerts,
+        "ollama_ok": ollama_ok,
+        "chroma_ok": chroma_ok,
+        "machine_count": len(machines),
+        "stale_machines": stale_machines,
+        "flagged_machines": flagged_machines,
+        "user_count": user_count,
+    }
+
+
+def _evaluate_controls(ctx):
+    def status(cond_pass, cond_warn=False):
+        return "pass" if cond_pass else ("warn" if cond_warn else "fail")
+
+    return [
+        {"id": "SEC-01", "category": "security", "name": "Intrusion Detection Coverage",
+         "description": "Suricata/Zeek sensors are actively producing telemetry.",
+         "status": status(ctx["total_events"] > 0)},
+        {"id": "SEC-02", "category": "security", "name": "Alert Triage Rate",
+         "description": "Alert volume stays within an acceptable share of total traffic.",
+         "status": status(ctx["alert_ratio"] < 0.25, ctx["alert_ratio"] < 0.5)},
+        {"id": "SEC-03", "category": "security", "name": "Malicious IP Response",
+         "description": "No Sentinel endpoint currently reports unresolved suspicious activity.",
+         "status": status(ctx["flagged_machines"] == 0, ctx["flagged_machines"] <= 1)},
+        {"id": "SEC-04", "category": "security", "name": "Threat Actor Volume",
+         "description": "Distinct attacking source IPs remain below the risk threshold.",
+         "status": status(ctx["unique_ips"] < 20, ctx["unique_ips"] < 50)},
+        {"id": "AVAIL-01", "category": "availability", "name": "AI Assistant Availability",
+         "description": "SIRA's local LLM and vector store are reachable.",
+         "status": status(ctx["ollama_ok"] and ctx["chroma_ok"], ctx["ollama_ok"] or ctx["chroma_ok"])},
+        {"id": "AVAIL-02", "category": "availability", "name": "Endpoint Heartbeat Coverage",
+         "description": "Registered Sentinel endpoints have checked in within the last 15 minutes.",
+         "status": status(ctx["machine_count"] > 0 and ctx["stale_machines"] == 0,
+                           ctx["machine_count"] > 0 and ctx["stale_machines"] < ctx["machine_count"])},
+        {"id": "CONF-01", "category": "confidentiality", "name": "Encrypted Session Observability",
+         "description": "TLS traffic is being observed and logged, confirming encryption-in-transit visibility.",
+         "status": status(ctx["tls_count"] > 0, ctx["total_events"] == 0)},
+        {"id": "CONF-02", "category": "confidentiality", "name": "DNS Exfiltration Watch",
+         "description": "DNS event volume stays within expected bounds (no tunnelling spike).",
+         "status": status(ctx["dns_ratio"] < 0.4, ctx["dns_ratio"] < 0.7)},
+        {"id": "PI-01", "category": "processing_integrity", "name": "Endpoint Process Integrity",
+         "description": "No Sentinel endpoint currently reports a suspicious process or connection.",
+         "status": status(ctx["flagged_machines"] == 0, ctx["flagged_machines"] <= 1)},
+        {"id": "PI-02", "category": "processing_integrity", "name": "Telemetry Pipeline Integrity",
+         "description": "The log ingestion pipeline (eve.json) is producing parsed events.",
+         "status": status(ctx["total_events"] > 0)},
+        {"id": "PRIV-01", "category": "privacy", "name": "Access Audit Trail",
+         "description": "User authentication activity is captured for accountability.",
+         "status": status(ctx["user_count"] > 0)},
+        {"id": "PRIV-02", "category": "privacy", "name": "Critical Alert Exposure",
+         "description": "No unresolved critical-severity alerts are outstanding.",
+         "status": status(ctx["critical_alerts"] == 0, ctx["critical_alerts"] <= 2)},
+    ]
+
+
+@app.route('/compliance/overview', methods=['GET'])
+def compliance_overview():
+    ctx = _compliance_context()
+    controls = _evaluate_controls(ctx)
+    weight = {"pass": 1, "warn": 0.5, "fail": 0}
+
+    criteria = []
+    for key, label in TSC_CATEGORIES.items():
+        cat_controls = [c for c in controls if c["category"] == key]
+        total = len(cat_controls) or 1
+        score = round(sum(weight[c["status"]] for c in cat_controls) / total * 100)
+        criteria.append({
+            "key": key,
+            "label": label,
+            "score": score,
+            "controls_passing": sum(1 for c in cat_controls if c["status"] == "pass"),
+            "controls_total": len(cat_controls),
+        })
+
+    overall_score = round(sum(c["score"] for c in criteria) / len(criteria)) if criteria else 0
+    return jsonify({
+        "overall_score": overall_score,
+        "criteria": criteria,
+        "controls_passing": sum(1 for c in controls if c["status"] == "pass"),
+        "controls_total": len(controls),
+        "findings_open": ctx["alert_count"],
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+    })
+
+
+@app.route('/compliance/controls', methods=['GET'])
+def compliance_controls():
+    ctx = _compliance_context()
+    return jsonify(_evaluate_controls(ctx))
+
+
+@app.route('/compliance/findings', methods=['GET'])
+def compliance_findings():
+    limit = min(int(request.args.get('limit', 10)), 200)
+    logs = load_logs()
+    alerts = [l for l in logs if l.get('event_type') == 'alert']
+    alerts.sort(key=lambda l: l.get('timestamp', ''), reverse=True)
+
+    severity_map = {1: "critical", 2: "elevated", 3: "informational"}
+    findings = []
+    for i, l in enumerate(alerts[:limit]):
+        a = l.get('alert', {})
+        severity = a.get('severity', 3)
+        findings.append({
+            "id": f"FND-{i+1:04d}",
+            "title": a.get('signature', 'Unknown signature'),
+            "category": a.get('category', 'Uncategorized'),
+            "severity": severity_map.get(severity, "informational"),
+            "src_ip": l.get('src_ip'),
+            "dest_ip": l.get('dest_ip'),
+            "detected_at": l.get('timestamp'),
+        })
+    return jsonify(findings)
+
+
+@app.route('/compliance/heatmap', methods=['GET'])
+def compliance_heatmap():
+    logs = load_logs()
+    grid = Counter()
+    for l in logs:
+        if l.get('event_type') != 'alert':
+            continue
+        date_str, hour = _log_date_hour(l.get('timestamp'))
+        if date_str is None:
+            continue
+        try:
+            weekday = datetime.strptime(date_str, "%Y-%m-%d").weekday()
+        except ValueError:
+            continue
+        grid[(weekday, hour)] += 1
+
+    cells = [{"weekday": wd, "hour": hr, "count": c} for (wd, hr), c in grid.items()]
+    return jsonify({"cells": cells, "max": max(grid.values()) if grid else 0})
+
+
+@app.route('/compliance/trend', methods=['GET'])
+def compliance_trend():
+    logs = load_logs()
+    by_day = {}
+    for l in logs:
+        date_str, _ = _log_date_hour(l.get('timestamp'))
+        if date_str is None:
+            continue
+        bucket = by_day.setdefault(date_str, {"total": 0, "alerts": 0})
+        bucket["total"] += 1
+        if l.get('event_type') == 'alert':
+            bucket["alerts"] += 1
+
+    series = []
+    for date_str in sorted(by_day.keys()):
+        b = by_day[date_str]
+        score = round(100 * (1 - (b["alerts"] / b["total"] if b["total"] else 0)))
+        series.append({"date": date_str, "score": max(0, min(100, score)),
+                        "alerts": b["alerts"], "total_events": b["total"]})
+    return jsonify(series)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Replaces the Analytics tab with a new SOC 2 Trust Service Criteria dashboard: 3D hero card, compliance score trend, audit findings table, alert heatmap, incident-origins map, control coverage chart, and TSC balances row. Backed by new /compliance/overview, /controls, /findings, /heatmap and /trend endpoints in the Flask API, which evaluate a small control catalog against real Suricata/Zeek/Sentinel telemetry rather than mock data. Updates the shared dark theme tokens to the new near-black palette and removes the now-unused legacy AnalyticsPage component.


Claude-Session: https://claude.ai/code/session_014KmxGfk3uGMRBjvGv7NZkL