### PR TITLE
Redesign compliance dashboard with cybersecurity ops theme

### DIFF
--- a/web-react/src/App.js
+++ b/web-react/src/App.js
@@ -301,6 +301,45 @@ const sharedCss = `
   .lollipop-col { display: flex; flex-direction: column; align-items: center; gap: 6px; flex: 1; }
   .lollipop-stem { width: 3px; border-radius: 2px; background: var(--border2); position: relative; }
   .lollipop-dot { width: 10px; height: 10px; border-radius: 50%; margin-top: -5px; }
+
+  /* ===== HUD / CYBER-OPS THEME ===== */
+  .hud-page { position: relative; }
+  .hud-page::before {
+    content: ''; position: absolute; inset: 0; pointer-events: none; z-index: 0;
+    background-image:
+      linear-gradient(rgba(77,216,232,0.035) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(77,216,232,0.035) 1px, transparent 1px);
+    background-size: 34px 34px;
+    -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black, transparent 75%);
+            mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black, transparent 75%);
+  }
+  .hud-page > * { position: relative; z-index: 1; }
+
+  .hud-card { --hud-accent: var(--accent); }
+  .hud-card::before, .hud-card::after { content: ''; position: absolute; width: 11px; height: 11px; border-color: var(--hud-accent); opacity: 0.6; pointer-events: none; z-index: 2; transition: opacity 0.2s; }
+  .hud-card::before { top: -1px; left: -1px; border-top: 1.5px solid; border-left: 1.5px solid; border-radius: 8px 0 0 0; }
+  .hud-card::after  { bottom: -1px; right: -1px; border-bottom: 1.5px solid; border-right: 1.5px solid; border-radius: 0 0 8px 0; }
+  .hud-card:hover::before, .hud-card:hover::after { opacity: 1; }
+  .hud-card-topline { position: absolute; top: 0; left: 16px; right: 16px; height: 1px; background: linear-gradient(90deg, transparent, var(--hud-accent), transparent); opacity: 0.5; }
+
+  .hud-live { display: inline-flex; align-items: center; gap: 5px; font-family: var(--mono); font-size: 8px; letter-spacing: 1.5px; color: var(--green); text-transform: uppercase; }
+  .hud-live-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); animation: blink 2s infinite; }
+
+  .hud-stat-strip { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+  .hud-stat-chip { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 14px 16px; display: flex; align-items: center; gap: 12px; position: relative; overflow: hidden; }
+  .hud-stat-icon { width: 32px; height: 32px; border-radius: 9px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .hud-stat-label { font-family: var(--mono); font-size: 8.5px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--text-dim); margin-bottom: 3px; }
+  .hud-stat-value { font-family: var(--display); font-size: 22px; font-weight: 700; color: var(--text); line-height: 1; }
+
+  .hud-scan-overlay { position: absolute; inset: 0; pointer-events: none; overflow: hidden; z-index: 5; }
+  .hud-scan-overlay::after {
+    content: ''; position: absolute; left: 0; right: 0; height: 90px; top: -90px;
+    background: linear-gradient(180deg, transparent, rgba(77,216,232,0.12), transparent);
+    animation: hud-scan 5s linear infinite;
+  }
+  @keyframes hud-scan { 0% { top: -90px; } 100% { top: 100%; } }
+
+  .radial-gauge-label { font-family: var(--display); font-weight: 700; }
 `;
 function SimpleExplain({ text }) {
   const [open, setOpen]       = useState(false);

--- a/web-react/src/Soc2Dashboard.js
+++ b/web-react/src/Soc2Dashboard.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo, memo } from "react";
+import { motion, animate } from "framer-motion";
 import { Canvas, useFrame } from "@react-three/fiber";
-import { MeshDistortMaterial, Sphere } from "@react-three/drei";
+import { MeshDistortMaterial, Sphere, Torus } from "@react-three/drei";
 import ThreatMap from "./ThreatMap";
 
 const FLASK_URL = "http://localhost:5000";
@@ -16,6 +17,27 @@ const TSC_COLORS = {
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const SEVERITY_LABEL = { critical: "Critical", elevated: "Elevated", informational: "Informational" };
 
+/* ── motion primitives ── */
+const fadeUp = {
+  hidden: { opacity: 0, y: 14 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.45, ease: "easeOut" } },
+};
+const staggerContainer = (stagger = 0.07, delay = 0) => ({
+  hidden: {},
+  show: { transition: { staggerChildren: stagger, delayChildren: delay } },
+});
+
+function useCountUp(target, duration = 1.1) {
+  const [display, setDisplay] = useState(0);
+  useEffect(() => {
+    const t = typeof target === "number" && !isNaN(target) ? target : 0;
+    const controls = animate(0, t, { duration, ease: "easeOut", onUpdate: (v) => setDisplay(Math.round(v)) });
+    return () => controls.stop();
+  }, [target, duration]);
+  return display;
+}
+
+/* ── icons (inline SVG — no emoji, matches the app's existing glyph convention) ── */
 function IconTrend() {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -51,25 +73,103 @@ function IconSparkle() {
     </svg>
   );
 }
-
-function BlobMesh() {
-  const meshRef = useRef();
-  useFrame((_, delta) => { if (meshRef.current) meshRef.current.rotation.y += delta * 0.25; });
+function IconActivity() {
   return (
-    <Sphere ref={meshRef} args={[1.15, 128, 128]}>
-      <MeshDistortMaterial color="#8B7CFF" attach="material" distort={0.45} speed={1.6} roughness={0.15} metalness={0.75} />
-    </Sphere>
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </svg>
+  );
+}
+function IconAlertTriangle() {
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}
+function IconGlobe() {
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" /><line x1="2" y1="12" x2="22" y2="12" /><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </svg>
+  );
+}
+function IconShieldCheck() {
+  return (
+    <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 22s8-4 8-11V5l-8-3-8 3v6c0 7 8 11 8 11z" /><path d="M9 12l2 2 4-4" />
+    </svg>
   );
 }
 
-function HeroBlob() {
+/* ── radial gauge (SVG ring, animated draw-on) ── */
+function RadialGauge({ value, size = 92, stroke = 7, color = "#4DD8E8", label }) {
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const displayValue = useCountUp(value ?? 0);
+  const offset = circumference - (Math.max(0, Math.min(100, value ?? 0)) / 100) * circumference;
   return (
-    <Canvas camera={{ position: [0, 0, 3] }} gl={{ antialias: true, alpha: true }}>
-      <ambientLight intensity={0.7} />
-      <pointLight position={[3, 3, 3]} intensity={45} color="#4DD8E8" />
-      <pointLight position={[-3, -2, 2]} intensity={35} color="#C93DE0" />
-      <pointLight position={[0, 3, -3]} intensity={25} color="#E8B84D" />
-      <BlobMesh />
+    <div style={{ position: "relative", width: size, height: size, flexShrink: 0 }}>
+      <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle cx={size / 2} cy={size / 2} r={radius} stroke="var(--border2)" strokeWidth={stroke} fill="none" />
+        <motion.circle
+          cx={size / 2} cy={size / 2} r={radius} stroke={color} strokeWidth={stroke} fill="none"
+          strokeLinecap="round" strokeDasharray={circumference}
+          initial={{ strokeDashoffset: circumference }}
+          animate={{ strokeDashoffset: offset }}
+          transition={{ duration: 1.2, ease: "easeOut" }}
+          style={{ filter: `drop-shadow(0 0 5px ${color}88)` }}
+        />
+      </svg>
+      <div style={{ position: "absolute", inset: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+        <span className="radial-gauge-label" style={{ fontSize: size * 0.24, color: "var(--text)" }}>{displayValue}%</span>
+        {label && <span style={{ fontFamily: "var(--mono)", fontSize: 8, color: "var(--text-dim)", letterSpacing: 1, marginTop: 2 }}>{label}</span>}
+      </div>
+    </div>
+  );
+}
+
+/* ── HUD stat chip with animated count ── */
+function HudStat({ icon, label, value, suffix = "", color = "#4DD8E8" }) {
+  const displayValue = useCountUp(value ?? 0);
+  return (
+    <motion.div className="bento-card hud-card hud-stat-chip" variants={fadeUp} style={{ "--hud-accent": color }}>
+      <div className="hud-card-topline" />
+      <div className="hud-stat-icon" style={{ background: `${color}1f`, color }}>{icon}</div>
+      <div>
+        <div className="hud-stat-label">{label}</div>
+        <div className="hud-stat-value" style={{ color }}>{displayValue}{suffix}</div>
+      </div>
+    </motion.div>
+  );
+}
+
+/* ── 3D hero visual: rotating network core + counter-rotating scan ring ── */
+function NetworkCore() {
+  const coreRef = useRef();
+  const ringRef = useRef();
+  useFrame((_, delta) => {
+    if (coreRef.current) coreRef.current.rotation.y += delta * 0.3;
+    if (ringRef.current) { ringRef.current.rotation.z -= delta * 0.5; ringRef.current.rotation.x = 1.2; }
+  });
+  return (
+    <>
+      <Sphere ref={coreRef} args={[0.95, 96, 96]}>
+        <MeshDistortMaterial color="#0F3B42" attach="material" distort={0.28} speed={1.4} roughness={0.25} metalness={0.85} emissive="#4DD8E8" emissiveIntensity={0.35} />
+      </Sphere>
+      <Torus ref={ringRef} args={[1.55, 0.015, 16, 100]}>
+        <meshBasicMaterial color="#4DD8E8" transparent opacity={0.55} />
+      </Torus>
+    </>
+  );
+}
+function HeroVisual() {
+  return (
+    <Canvas camera={{ position: [0, 0, 3.4] }} gl={{ antialias: true, alpha: true }}>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[3, 3, 3]} intensity={50} color="#4DD8E8" />
+      <pointLight position={[-3, -2, 2]} intensity={30} color="#C93DE0" />
+      <NetworkCore />
     </Canvas>
   );
 }
@@ -79,6 +179,7 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
   const [findings, setFindings]   = useState([]);
   const [heatmap, setHeatmap]     = useState({ cells: [], max: 0 });
   const [trend, setTrend]         = useState([]);
+  const [threatOrigins, setThreatOrigins] = useState(0);
   const [activeWidget, setActiveWidget] = useState("trend");
 
   const trendChartRef      = useRef(null);
@@ -93,6 +194,7 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
     fetch(`${FLASK_URL}/compliance/findings?limit=8`).then(r => r.json()).then(d => setFindings(Array.isArray(d) ? d : [])).catch(() => {});
     fetch(`${FLASK_URL}/compliance/heatmap`).then(r => r.json()).then(d => setHeatmap(d || { cells: [], max: 0 })).catch(() => {});
     fetch(`${FLASK_URL}/compliance/trend`).then(r => r.json()).then(d => setTrend(Array.isArray(d) ? d : [])).catch(() => {});
+    fetch(`${FLASK_URL}/top-ips?limit=15`).then(r => r.json()).then(d => setThreatOrigins(Array.isArray(d) ? d.length : 0)).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -152,28 +254,48 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
   const findingsRelative = (ts) => {
     if (!ts) return "--";
     const d = new Date(ts);
-    if (isNaN(d.getTime())) return ts.slice(5, 16).replace("T", " ");
+    if (isNaN(d.getTime())) return ts.slice(11, 16);
     const pad = (n) => String(n).padStart(2, "0");
-    return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
   };
+  const findingsOpen = overview?.findings_open ?? 0;
 
   return (
-    <div className="page" style={{ padding: 20 }}>
-      <div className="page-title">SOC 2 Compliance Dashboard</div>
-      <div className="page-sub">TRUST SERVICE CRITERIA — LIVE FROM SURICATA, ZEEK &amp; SENTINEL TELEMETRY</div>
+    <div className="page hud-page" style={{ padding: 20 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", marginBottom: 18, flexWrap: "wrap", gap: 10 }}>
+        <div>
+          <div className="page-title">SOC 2 Compliance Dashboard</div>
+          <div className="page-sub" style={{ marginBottom: 0 }}>TRUST SERVICE CRITERIA — LIVE FROM SURICATA, ZEEK &amp; SENTINEL TELEMETRY</div>
+        </div>
+        <span className="hud-live"><span className="hud-live-dot" />Live telemetry</span>
+      </div>
+
+      {/* ── HUD STATUS STRIP ── */}
+      <motion.div className="hud-stat-strip" style={{ marginBottom: 14 }} variants={staggerContainer(0.08)} initial="hidden" animate="show">
+        <HudStat icon={<IconShieldCheck />} label="Compliance Score" value={overview?.overall_score} suffix="%" color="#4DD8E8" />
+        <HudStat icon={<IconAlertTriangle />} label="Open Findings" value={findingsOpen} color={findingsOpen > 0 ? "#E15554" : "#22D97A"} />
+        <HudStat icon={<IconGlobe />} label="Threat Origins" value={threatOrigins} color="#C93DE0" />
+        <HudStat icon={<IconActivity />} label="Controls Passing" value={overview?.controls_passing} suffix={` / ${overview?.controls_total ?? "--"}`} color="#22D97A" />
+      </motion.div>
 
       {/* ── TOP ROW: hero + trend + widget switcher ── */}
-      <div style={{ display: "grid", gridTemplateColumns: "260px 1fr 220px", gap: 14, marginBottom: 14 }}>
-        <div className="bento-card" style={{ padding: 16, display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
-          <div style={{ width: "100%", height: 150, borderRadius: 14, overflow: "hidden", background: "radial-gradient(circle at 50% 40%, rgba(139,124,255,0.18), transparent 70%)" }}>
-            <HeroBlob />
+      <motion.div style={{ display: "grid", gridTemplateColumns: "260px 1fr 220px", gap: 14, marginBottom: 14 }} variants={staggerContainer(0.1)} initial="hidden" animate="show">
+        <motion.div className="bento-card hud-card" variants={fadeUp} style={{ "--hud-accent": "#8B7CFF", padding: 16, display: "flex", flexDirection: "column", alignItems: "center", gap: 12 }}>
+          <div className="hud-card-topline" />
+          <div style={{ width: "100%", height: 150, borderRadius: 14, overflow: "hidden", background: "radial-gradient(circle at 50% 40%, rgba(77,216,232,0.14), transparent 70%)" }}>
+            <HeroVisual />
           </div>
-          <button className="bento-pill" onClick={() => onAskSira && onAskSira("Give me a summary of our current SOC 2 compliance posture and any open findings.")}>
+          <motion.button
+            className="bento-pill" onClick={() => onAskSira && onAskSira("Give me a summary of our current SOC 2 compliance posture and any open findings.")}
+            animate={{ scale: [1, 1.04, 1] }} transition={{ duration: 2.6, repeat: Infinity, ease: "easeInOut" }}
+            whileHover={{ scale: 1.08 }} whileTap={{ scale: 0.96 }}
+          >
             <IconSparkle /> AI analytics
-          </button>
-        </div>
+          </motion.button>
+        </motion.div>
 
-        <div className="bento-card" ref={trendSectionRef}>
+        <motion.div className="bento-card hud-card" variants={fadeUp} style={{ "--hud-accent": "#4DD8E8" }} ref={trendSectionRef}>
+          <div className="hud-card-topline" />
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
             <div>
               <div className="bento-card-title">Compliance Score Trend</div>
@@ -191,7 +313,7 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
           <div style={{ position: "relative", height: 190, marginTop: 14 }}>
             <canvas ref={trendChartRef} role="img" aria-label="Compliance score trend line chart" />
           </div>
-        </div>
+        </motion.div>
 
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gridTemplateRows: "1fr 1fr", gap: 10 }}>
           {[
@@ -200,31 +322,37 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
             { key: "findings", icon: <IconTable />,     label: "Findings",     ref: findingsSectionRef },
             { key: "heatmap",  icon: <IconGrid />,      label: "Alert Heatmap", ref: heatmapSectionRef },
           ].map(w => (
-            <div key={w.key} className={`bento-card bento-widget${activeWidget === w.key ? " active" : ""}`} onClick={() => jumpTo(w.key, w.ref)}>
+            <motion.div
+              key={w.key} variants={fadeUp} whileHover={{ y: -2 }} whileTap={{ scale: 0.97 }}
+              className={`bento-card hud-card bento-widget${activeWidget === w.key ? " active" : ""}`}
+              style={{ "--hud-accent": "#4DD8E8" }} onClick={() => jumpTo(w.key, w.ref)}
+            >
+              <div className="hud-card-topline" />
               <div className="bento-widget-icon">{w.icon}</div>
               <div className="bento-widget-label">{w.label}</div>
-            </div>
+            </motion.div>
           ))}
         </div>
-      </div>
+      </motion.div>
 
       {/* ── MIDDLE ROW: findings / heatmap / map ── */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 14, marginBottom: 14 }}>
-        <div className="bento-card" ref={findingsSectionRef}>
+      <motion.div style={{ display: "grid", gridTemplateColumns: "0.9fr 0.9fr 1.2fr", gap: 14, marginBottom: 14 }} variants={staggerContainer(0.12)} initial="hidden" animate="show">
+        <motion.div className="bento-card hud-card" variants={fadeUp} style={{ "--hud-accent": findingsOpen > 0 ? "#E15554" : "#22D97A" }} ref={findingsSectionRef}>
+          <div className="hud-card-topline" />
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
             <div className="bento-card-title">Audit Findings</div>
             <button className="bento-see-all" onClick={() => onSeeFindings && onSeeFindings()}>See all</button>
           </div>
           <div style={{ overflowX: "auto" }}>
             <table className="bento-table" style={{ tableLayout: "fixed", width: "100%" }}>
-              <colgroup><col style={{ width: "42%" }} /><col style={{ width: "22%" }} /><col style={{ width: "20%" }} /><col style={{ width: "16%" }} /></colgroup>
+              <colgroup><col style={{ width: "38%" }} /><col style={{ width: "24%" }} /><col style={{ width: "22%" }} /><col style={{ width: "16%" }} /></colgroup>
               <thead><tr><th>Signature</th><th>Source</th><th>Status</th><th>Time</th></tr></thead>
               <tbody>
                 {findings.length === 0 && (
                   <tr><td colSpan={4} style={{ color: "var(--text-dim)" }}>No open findings</td></tr>
                 )}
-                {findings.map(f => (
-                  <tr key={f.id}>
+                {findings.map((f, i) => (
+                  <motion.tr key={f.id} initial={{ opacity: 0, x: -8 }} animate={{ opacity: 1, x: 0 }} transition={{ duration: 0.3, delay: i * 0.05 }}>
                     <td style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={f.title}>{f.title}</td>
                     <td style={{ fontFamily: "var(--mono)", fontSize: 11, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.src_ip || "--"}</td>
                     <td style={{ overflow: "hidden" }}>
@@ -233,17 +361,18 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
                         {SEVERITY_LABEL[f.severity] || f.severity}
                       </span>
                     </td>
-                    <td style={{ fontFamily: "var(--mono)", fontSize: 10, whiteSpace: "nowrap" }}>{findingsRelative(f.detected_at)}</td>
-                  </tr>
+                    <td style={{ fontFamily: "var(--mono)", fontSize: 10, whiteSpace: "nowrap", overflow: "hidden" }}>{findingsRelative(f.detected_at)}</td>
+                  </motion.tr>
                 ))}
               </tbody>
             </table>
           </div>
-        </div>
+        </motion.div>
 
-        <div className="bento-card" ref={heatmapSectionRef}>
+        <motion.div className="bento-card hud-card" variants={fadeUp} style={{ "--hud-accent": "#E8B84D" }} ref={heatmapSectionRef}>
+          <div className="hud-card-topline" />
           <div className="bento-card-title" style={{ marginBottom: 14 }}>Alert Heatmap</div>
-          <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+          <motion.div initial={{ opacity: 0, scale: 0.97 }} animate={{ opacity: 1, scale: 1 }} transition={{ duration: 0.5 }} style={{ display: "flex", flexDirection: "column", gap: 3 }}>
             {WEEKDAYS.map((day, wd) => (
               <div key={day} className="bento-heat-row">
                 <span className="bento-heat-label">{day}</span>
@@ -255,43 +384,52 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
                       key={hr}
                       className="bento-heat-cell"
                       title={`${day} ${hr}:00 — ${count} alerts`}
-                      style={{ background: count === 0 ? "var(--bg3)" : `rgba(77,216,232,${0.15 + intensity * 0.8})` }}
+                      style={{ background: count === 0 ? "var(--bg3)" : `rgba(232,184,77,${0.15 + intensity * 0.8})` }}
                     />
                   );
                 })}
               </div>
             ))}
-          </div>
+          </motion.div>
           <div style={{ display: "flex", justifyContent: "space-between", marginTop: 8 }}>
             <span className="bento-heat-label">00h</span><span className="bento-heat-label">12h</span><span className="bento-heat-label">23h</span>
           </div>
-        </div>
+        </motion.div>
 
-        <div className="bento-card" style={{ padding: 0, overflow: "hidden" }}>
-          <div style={{ position: "absolute", top: 16, left: 20, zIndex: 500 }}>
+        <motion.div className="bento-card hud-card" variants={fadeUp} style={{ "--hud-accent": "#C93DE0", padding: 0, overflow: "hidden" }}>
+          <div className="hud-card-topline" />
+          <div className="hud-scan-overlay" />
+          <div style={{ position: "absolute", top: 16, left: 20, zIndex: 500, display: "flex", alignItems: "center", gap: 10 }}>
             <div className="bento-card-title" style={{ fontSize: 14 }}>Incident Origins</div>
+            <span className="hud-live"><span className="hud-live-dot" style={{ background: "var(--magenta)", boxShadow: "0 0 6px var(--magenta)" }} />Scanning</span>
           </div>
           <div style={{ height: 320 }}>
             <ThreatMap />
           </div>
-        </div>
-      </div>
+        </motion.div>
+      </motion.div>
 
       {/* ── BOTTOM ROW: control coverage lollipop + TSC balances ── */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1.6fr", gap: 14 }}>
-        <div className="bento-card" ref={coverageSectionRef}>
+      <motion.div style={{ display: "grid", gridTemplateColumns: "1fr 1.6fr", gap: 14 }} variants={staggerContainer(0.12)} initial="hidden" animate="show">
+        <motion.div className="bento-card hud-card" variants={fadeUp} style={{ "--hud-accent": "#4DD8E8" }} ref={coverageSectionRef}>
+          <div className="hud-card-topline" />
           <div className="bento-card-title" style={{ marginBottom: 4 }}>Control Coverage by Criteria</div>
           <div className="bento-card-sub" style={{ marginBottom: 18 }}>{overview?.controls_passing ?? "--"} / {overview?.controls_total ?? "--"} controls passing</div>
           <div style={{ display: "flex", alignItems: "flex-end", height: 150, gap: 4 }}>
-            {TSC_ORDER.map(key => {
+            {TSC_ORDER.map((key, i) => {
               const c = criteria.find(x => x.key === key);
               const score = c?.score ?? 0;
               const color = TSC_COLORS[key];
               return (
                 <div key={key} className="lollipop-col">
-                  <div className="lollipop-stem" style={{ height: `${Math.max(score, 4)}%`, background: `linear-gradient(180deg, transparent, ${color}66)` }}>
+                  <motion.div
+                    className="lollipop-stem"
+                    style={{ background: `linear-gradient(180deg, transparent, ${color}66)` }}
+                    initial={{ height: 0 }} animate={{ height: `${Math.max(score, 4)}%` }}
+                    transition={{ duration: 0.9, delay: i * 0.08, ease: "easeOut" }}
+                  >
                     <div className="lollipop-dot" style={{ background: color, boxShadow: `0 0 8px ${color}` }} />
-                  </div>
+                  </motion.div>
                 </div>
               );
             })}
@@ -303,28 +441,28 @@ const Soc2Dashboard = memo(function Soc2Dashboard({ onAskSira, onSeeFindings }) 
               </div>
             ))}
           </div>
-        </div>
+        </motion.div>
 
-        <div className="bento-card">
+        <motion.div className="bento-card hud-card" variants={fadeUp} style={{ "--hud-accent": "#22D97A" }}>
+          <div className="hud-card-topline" />
           <div className="bento-card-title" style={{ marginBottom: 16 }}>Trust Service Criteria Balances</div>
           <div className="balance-row" style={{ gridTemplateColumns: `repeat(${TSC_ORDER.length}, 1fr)` }}>
             {TSC_ORDER.map(key => {
               const c = criteria.find(x => x.key === key);
               const score = c?.score ?? 0;
-              const up = score >= 80;
               return (
-                <div key={key} className="balance-card">
-                  <div className="balance-label">{c?.label || key}</div>
-                  <div className="balance-value">{overview ? `${score}%` : "--"}</div>
-                  <div className={`balance-delta ${up ? "up" : "down"}`}>
-                    {up ? "▲" : "▼"} {c ? `${c.controls_passing}/${c.controls_total} controls` : ""}
+                <div key={key} className="balance-card" style={{ alignItems: "center", textAlign: "center" }}>
+                  <RadialGauge value={overview ? score : 0} size={78} stroke={6} color={TSC_COLORS[key]} />
+                  <div className="balance-label" style={{ marginTop: 4 }}>{c?.label || key}</div>
+                  <div className="balance-delta" style={{ color: "var(--text-dim)", fontWeight: 400 }}>
+                    {c ? `${c.controls_passing}/${c.controls_total} controls` : ""}
                   </div>
                 </div>
               );
             })}
           </div>
-        </div>
-      </div>
+        </motion.div>
+      </motion.div>
     </div>
   );
 });

--- a/web-react/src/ThreatMap.js
+++ b/web-react/src/ThreatMap.js
@@ -47,7 +47,7 @@ export default function ThreatMap() {
         <div style={{
           position: "absolute", inset: 0, zIndex: 1000,
           display: "flex", alignItems: "center", justifyContent: "center",
-          background: "rgba(8,12,18,0.8)", fontFamily: "var(--mono)",
+          background: "rgba(10,10,12,0.85)", fontFamily: "var(--mono)",
           fontSize: 11, color: "var(--accent)", letterSpacing: 2
         }}>
           ◈ LOADING THREAT MAP...
@@ -57,7 +57,7 @@ export default function ThreatMap() {
       <MapContainer
         center={[20, 0]}
         zoom={2}
-        style={{ width: "100%", height: "100%", background: "#080c12" }}
+        style={{ width: "100%", height: "100%", background: "#0A0A0C" }}
         zoomControl={false}
         attributionControl={false}
       >
@@ -70,10 +70,10 @@ export default function ThreatMap() {
         <CircleMarker
           center={NZ_COORDS}
           radius={10}
-          pathOptions={{ color: "#00e5ff", fillColor: "#00e5ff", fillOpacity: 0.8, weight: 2 }}
+          pathOptions={{ color: "#4DD8E8", fillColor: "#4DD8E8", fillOpacity: 0.8, weight: 2 }}
         >
           <Popup>
-            <div style={{ fontFamily: "monospace", fontSize: 11, color: "#00e5ff", background: "#080c12", padding: 8, borderRadius: 4 }}>
+            <div style={{ fontFamily: "monospace", fontSize: 11, color: "#4DD8E8", background: "#0A0A0C", padding: 8, borderRadius: 4 }}>
               <strong>SIRA SERVER</strong><br/>
               Auckland, New Zealand<br/>
               SOC Copilot v4
@@ -85,7 +85,7 @@ export default function ThreatMap() {
         {attackers.map((a, i) => {
           const size      = 4 + (a.count / maxCount) * 14;
           const opacity   = 0.5 + (a.count / maxCount) * 0.5;
-          const color     = a.count > maxCount * 0.7 ? "#ff3d5a" : a.count > maxCount * 0.3 ? "#ffaa00" : "#b47cff";
+          const color     = a.count > maxCount * 0.7 ? "#E15554" : a.count > maxCount * 0.3 ? "#E8B84D" : "#C93DE0";
 
           return (
             <div key={i}>
@@ -115,15 +115,15 @@ export default function ThreatMap() {
       {/* Legend */}
       <div style={{
         position: "absolute", bottom: 16, left: 16, zIndex: 1000,
-        background: "rgba(8,12,18,0.9)", border: "1px solid rgba(0,229,255,0.2)",
+        background: "rgba(10,10,12,0.92)", border: "1px solid rgba(77,216,232,0.2)",
         borderRadius: 6, padding: "10px 14px", fontFamily: "var(--mono)", fontSize: 9
       }}>
         <div style={{ color: "var(--accent)", letterSpacing: 2, marginBottom: 8 }}>THREAT ORIGINS</div>
         {[
-          { color: "#ff3d5a", label: "HIGH ACTIVITY" },
-          { color: "#ffaa00", label: "MEDIUM ACTIVITY" },
-          { color: "#b47cff", label: "LOW ACTIVITY" },
-          { color: "#00e5ff", label: "SIRA SERVER (NZ)" },
+          { color: "#E15554", label: "HIGH ACTIVITY" },
+          { color: "#E8B84D", label: "MEDIUM ACTIVITY" },
+          { color: "#C93DE0", label: "LOW ACTIVITY" },
+          { color: "#4DD8E8", label: "SIRA SERVER (NZ)" },
         ].map((item, i) => (
           <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
             <div style={{ width: 8, height: 8, borderRadius: "50%", background: item.color, boxShadow: `0 0 6px ${item.color}` }} />
@@ -136,11 +136,11 @@ export default function ThreatMap() {
       {/* Attack count */}
       <div style={{
         position: "absolute", top: 16, right: 16, zIndex: 1000,
-        background: "rgba(8,12,18,0.9)", border: "1px solid rgba(255,61,90,0.3)",
+        background: "rgba(10,10,12,0.92)", border: "1px solid rgba(225,85,84,0.3)",
         borderRadius: 6, padding: "10px 14px", fontFamily: "var(--mono)", textAlign: "right"
       }}>
         <div style={{ fontSize: 7, color: "var(--text-dim)", letterSpacing: 2, marginBottom: 4 }}>ACTIVE THREATS</div>
-        <div style={{ fontSize: 24, fontWeight: 700, color: "#ff3d5a" }}>{attackers.length}</div>
+        <div style={{ fontSize: 24, fontWeight: 700, color: "#E15554" }}>{attackers.length}</div>
         <div style={{ fontSize: 7, color: "var(--text-dim)", letterSpacing: 1 }}>UNIQUE ORIGINS</div>
       </div>
     </div>


### PR DESCRIPTION
Reworks the SOC 2 dashboard's visual language toward a security operations center feel instead of the earlier fintech-style bento grid:
- HUD status strip with animated (framer-motion count-up) stats
- SVG radial gauges for compliance score and TSC balances, animated draw-on
- HUD corner-bracket card framing, scanline/grid page background, live pulsing status badges, and a scanning-sweep overlay on the map card
- 3D hero visual replaced with a network-core sphere + orbiting scan ring (react-three-fiber/drei), matching a security/telemetry motif
- Staggered entrance animations and per-row findings animation via framer-motion, capped to small item counts per animation perf guidance
- ThreatMap.js recolored (cyan/amber/red/magenta) to match the new palette

All data wiring to the real /compliance/* endpoints and existing telemetry sources is unchanged.


Claude-Session: https://claude.ai/code/session_014KmxGfk3uGMRBjvGv7NZkL