### PR TITLE
SC-65: honeypot log sync, Ollama embeddings fix, Hermes grounding fixes

### DIFF
--- a/ai/hermes_agent.py
+++ b/ai/hermes_agent.py
@@ -1,9 +1,34 @@
 import os
+import re
 import json
+import ipaddress
 import requests
 from langchain_ollama import OllamaLLM
 
 FLASK_URL = "http://localhost:5000"
+
+# IPs that are internal infrastructure, not external attackers, even though
+# they can rack up huge raw event counts (Azure's platform/metadata
+# services in particular). Never picked as an investigation target, and
+# the final report is explicitly told not to describe traffic from these
+# as an attack.
+KNOWN_PLATFORM_IPS = {
+    "168.63.129.16",   # Azure host wireserver (health checks, agent comms)
+    "169.254.169.254", # Azure/cloud instance metadata service (IMDS)
+}
+
+
+def _is_internal_or_platform_ip(ip: str) -> bool:
+    """True for private/RFC1918 addresses or known cloud platform IPs --
+    traffic to/from these is infrastructure noise, not an external attacker,
+    regardless of how many events it generates."""
+    if ip in KNOWN_PLATFORM_IPS:
+        return True
+    try:
+        return ipaddress.ip_address(ip).is_private
+    except ValueError:
+        return False
+
 
 # ── TOOLS ────────────────────────────────────────────────────────────────
 
@@ -22,6 +47,19 @@ def search_logs(query: str) -> str:
     except Exception as e:
         return f"Log search failed: {str(e)}"
 
+
+def _search_logs_raw(query: str, limit: int = 100):
+    """Same query as search_logs(), but returns parsed JSON instead of a
+    formatted string -- used internally to pick a real signature for the
+    CVE lookup rather than guessing at a generic phrase."""
+    try:
+        res = requests.get(f"{FLASK_URL}/search", params={"q": query}, timeout=10)
+        data = res.json()
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
 def check_reputation(ip: str) -> str:
     """Check IP reputation on AbuseIPDB."""
     try:
@@ -35,6 +73,7 @@ def check_reputation(ip: str) -> str:
                 f"- Total Reports: {data.get('reports')}")
     except Exception as e:
         return f"Reputation check failed: {str(e)}"
+
 
 def lookup_cve(signature: str) -> str:
     """Look up CVEs related to an attack signature from NVD database."""
@@ -53,6 +92,7 @@ def lookup_cve(signature: str) -> str:
     except Exception as e:
         return f"CVE lookup failed: {str(e)}"
 
+
 def correlate_zeek(ip: str) -> str:
     """Correlate Suricata alerts with Zeek connection logs for an IP."""
     try:
@@ -69,6 +109,7 @@ def correlate_zeek(ip: str) -> str:
         return result
     except Exception as e:
         return f"Zeek correlation failed: {str(e)}"
+
 
 def get_stats(query: str = "") -> str:
     """Get overall network statistics — total events, alerts, unique IPs."""
@@ -87,65 +128,127 @@ def get_stats(query: str = "") -> str:
     except Exception as e:
         return f"Stats fetch failed: {str(e)}"
 
+
+def _fetch_top_ips_raw(limit: int = 5):
+    """Same data as get_top_ips(), but as parsed JSON -- used internally to
+    pick a real, non-internal IP to investigate, instead of a hardcoded
+    placeholder."""
+    try:
+        res = requests.get(f"{FLASK_URL}/top-ips", params={"limit": limit}, timeout=10)
+        data = res.json()
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
 def get_top_ips(query: str = "") -> str:
     """Get top attacking IPs from the network logs."""
-    try:
-        res = requests.get(f"{FLASK_URL}/top-ips?limit=5", timeout=10)
-        data = res.json()
-        result = "Top 5 attacking IPs:\n"
-        for item in data:
-            result += f"- {item['ip']}: {item['count']} events\n"
-        return result
-    except Exception as e:
-        return f"Top IPs fetch failed: {str(e)}"
+    data = _fetch_top_ips_raw(limit=5)
+    if not data:
+        return "Top IPs fetch failed: no data returned"
+    result = "Top 5 attacking IPs:\n"
+    for item in data:
+        result += f"- {item['ip']}: {item['count']} events\n"
+    return result
 
-# ── TOOL DEFINITIONS ─────────────────────────────────────────────────────
+
+def _pick_target_ip(task: str, top_ips_data):
+    """Prefer an IP explicitly named in the task. Otherwise pick the
+    highest-volume IP that ISN'T internal/platform infrastructure -- never
+    fall back to a hardcoded placeholder IP, since that gets fed to every
+    tool as if it were real and the final report has no way to know it
+    wasn't. Returns None if nothing external is found in the data at all;
+    the report generation step is expected to say so honestly rather than
+    inventing a target.
+    """
+    ip_match = re.findall(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', task)
+    if ip_match:
+        return ip_match[0]
+    for item in top_ips_data:
+        ip = item.get("ip")
+        if ip and not _is_internal_or_platform_ip(ip):
+            return ip
+    return None
+
+
+def _pick_cve_search_term(target_ip: str, raw_logs):
+    """Use a real alert signature actually seen for this IP, not a generic
+    guessed phrase -- a generic query is what surfaced an unrelated CVE
+    (Dell DRAC4 firmware) against pure SSH-scanning traffic last time.
+    Returns None if no alert signature is available to search against.
+    """
+    for log in raw_logs:
+        if log.get("event_type") != "alert":
+            continue
+        sig = log.get("alert", {}).get("signature")
+        if sig:
+            return sig
+    return None
+
 
 # ── AGENT RUNNER ─────────────────────────────────────────────────────────
 
 def run_hermes_agent(task: str) -> dict:
     llm = OllamaLLM(model="nous-hermes2", temperature=0.3, num_predict=2048)
-    
+
     steps = []
-    
+
     # Step 1 — Get stats
     print("Step 1: Getting network stats...")
     stats_result = get_stats("")
     steps.append({"step": 1, "tool": "get_stats", "input": "", "result": stats_result, "status": "done"})
-    
+
     # Step 2 — Get top IPs
     print("Step 2: Getting top IPs...")
+    top_ips_data = _fetch_top_ips_raw(limit=5)
     ips_result = get_top_ips("")
     steps.append({"step": 2, "tool": "get_top_ips", "input": "", "result": ips_result, "status": "done"})
-    
-    # Step 3 — Extract IP from task or use top IP
-    import re
-    ip_match = re.findall(r'\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b', task)
-    target_ip = ip_match[0] if ip_match else "185.220.101.45"
-    
-    # Step 4 — Search logs for target IP
-    print(f"Step 3: Searching logs for {target_ip}...")
-    logs_result = search_logs(target_ip)
-    steps.append({"step": 3, "tool": "search_logs", "input": target_ip, "result": logs_result, "status": "done"})
-    
-    # Step 5 — Check reputation
-    print(f"Step 4: Checking reputation of {target_ip}...")
-    rep_result = check_reputation(target_ip)
-    steps.append({"step": 4, "tool": "check_reputation", "input": target_ip, "result": rep_result, "status": "done"})
-    
-    # Step 6 — CVE lookup
-    print("Step 5: Looking up CVEs...")
-    cve_result = lookup_cve("network scan SSH brute force")
-    steps.append({"step": 5, "tool": "lookup_cve", "input": "network scan SSH brute force", "result": cve_result, "status": "done"})
-    
-    # Step 7 — Zeek correlation
-    print(f"Step 6: Correlating Zeek data for {target_ip}...")
-    zeek_result = correlate_zeek(target_ip)
-    steps.append({"step": 6, "tool": "correlate_zeek", "input": target_ip, "result": zeek_result, "status": "done"})
-    
+
+    # Step 3 — Pick a real target IP: explicit from the task, else the
+    # highest-volume genuinely external IP. No hardcoded placeholder.
+    target_ip = _pick_target_ip(task, top_ips_data)
+
+    if target_ip is None:
+        # Nothing external to investigate in the current data -- say so
+        # honestly instead of inventing a target IP to run the rest of the
+        # pipeline against.
+        no_target_msg = "No external (non-internal) attacking IP found in current top-IPs data."
+        steps.append({"step": 3, "tool": "search_logs", "input": "(none)", "result": no_target_msg, "status": "skipped"})
+        steps.append({"step": 4, "tool": "check_reputation", "input": "(none)", "result": no_target_msg, "status": "skipped"})
+        steps.append({"step": 5, "tool": "lookup_cve", "input": "(none)", "result": no_target_msg, "status": "skipped"})
+        steps.append({"step": 6, "tool": "correlate_zeek", "input": "(none)", "result": no_target_msg, "status": "skipped"})
+        logs_result = rep_result = cve_result = zeek_result = no_target_msg
+        raw_logs = []
+    else:
+        # Step 4 — Search logs for target IP
+        print(f"Step 3: Searching logs for {target_ip}...")
+        raw_logs = _search_logs_raw(target_ip)
+        logs_result = search_logs(target_ip)
+        steps.append({"step": 3, "tool": "search_logs", "input": target_ip, "result": logs_result, "status": "done"})
+
+        # Step 5 — Check reputation
+        print(f"Step 4: Checking reputation of {target_ip}...")
+        rep_result = check_reputation(target_ip)
+        steps.append({"step": 4, "tool": "check_reputation", "input": target_ip, "result": rep_result, "status": "done"})
+
+        # Step 6 — CVE lookup, driven by a real detected signature
+        cve_search_term = _pick_cve_search_term(target_ip, raw_logs)
+        if cve_search_term:
+            print(f"Step 5: Looking up CVEs for signature '{cve_search_term}'...")
+            cve_result = lookup_cve(cve_search_term)
+            steps.append({"step": 5, "tool": "lookup_cve", "input": cve_search_term, "result": cve_result, "status": "done"})
+        else:
+            cve_result = f"No alert signature detected for {target_ip} to correlate against CVEs."
+            steps.append({"step": 5, "tool": "lookup_cve", "input": "(no signature)", "result": cve_result, "status": "skipped"})
+
+        # Step 7 — Zeek correlation
+        print(f"Step 6: Correlating Zeek data for {target_ip}...")
+        zeek_result = correlate_zeek(target_ip)
+        steps.append({"step": 6, "tool": "correlate_zeek", "input": target_ip, "result": zeek_result, "status": "done"})
+
     # Step 8 — Generate final report with Hermes
     print("Step 7: Generating investigation report with Nous Hermes2...")
-    
+
     prompt = f"""You are SIRA — Security Incident Response Assistant powered by Nous Hermes2.
 You have completed an autonomous investigation. Here are the results:
 
@@ -157,17 +260,22 @@ NETWORK STATISTICS:
 TOP ATTACKING IPs:
 {ips_result}
 
-LOG SEARCH RESULTS for {target_ip}:
+LOG SEARCH RESULTS for {target_ip or "(no external target identified)"}:
 {logs_result}
 
-REPUTATION CHECK for {target_ip}:
+REPUTATION CHECK for {target_ip or "(no external target identified)"}:
 {rep_result}
 
 CVE LOOKUP RESULTS:
 {cve_result}
 
-ZEEK CORRELATION for {target_ip}:
+ZEEK CORRELATION for {target_ip or "(no external target identified)"}:
 {zeek_result}
+
+STRICT GROUNDING RULES — follow these exactly:
+- Only reference IP addresses, CVE identifiers, signatures, and figures that appear explicitly in the tool results above. Never invent or assume an IP, CVE, or vulnerability not listed above.
+- Private/internal IP addresses (10.x.x.x, 172.16-31.x.x, 192.168.x.x) and known cloud platform IPs (168.63.129.16, 169.254.169.254) are internal infrastructure traffic, not external attackers -- even if they show a very high event count. Do not describe activity from these IPs as unauthorized access, an intrusion, or an attack.
+- If no external attacker or no relevant CVE was found in the results above, say so plainly instead of filling the gap with a plausible-sounding but unverified claim.
 
 Based on all this intelligence, write a comprehensive investigation report with:
 
@@ -191,12 +299,13 @@ RECOMMENDED ACTIONS:
 Write clearly for a junior SOC analyst."""
 
     final_answer = llm.invoke(prompt)
-    
+
     return {
         "steps": steps,
         "answer": final_answer,
         "total_steps": len(steps)
     }
+
 
 if __name__ == "__main__":
     print("Testing Hermes Agent...")

--- a/ai/honeypot_log_sync.py
+++ b/ai/honeypot_log_sync.py
@@ -1,0 +1,120 @@
+"""
+Honeypot log sync -- pulls eve.json (Suricata) and conn.log (Zeek) from the
+public-facing Azure honeypot VM via SFTP, polling every 15 seconds. Only
+downloads when the remote file's size has changed since the last poll, so
+idle periods don't cause constant re-transfer of an unchanged file.
+
+Designed to run as a background daemon thread started once from app.py at
+Flask startup (see start_background_sync()), but can also be run standalone
+for testing:
+
+    python ai/honeypot_log_sync.py
+
+Connection details default to the values used throughout this project's
+setup, but can be overridden via environment variables without editing code:
+
+    HONEYPOT_HOST      (default: 13.70.108.223)
+    HONEYPOT_USER      (default: sirauser)
+    HONEYPOT_KEY_PATH  (default: ~/.ssh/sira_honeypot)
+"""
+
+import os
+import time
+import threading
+
+import paramiko
+
+HONEYPOT_HOST = os.getenv("HONEYPOT_HOST", "13.70.108.223")
+HONEYPOT_USER = os.getenv("HONEYPOT_USER", "sirauser")
+HONEYPOT_KEY_PATH = os.getenv("HONEYPOT_KEY_PATH", os.path.expanduser("~/.ssh/sira_honeypot"))
+
+# Suricata's eve.json lives at the standard system path; Zeek (installed via
+# the openSUSE OBS package) writes conn.log under its own spool directory.
+REMOTE_EVE_JSON = "/var/log/suricata/eve.json"
+REMOTE_CONN_LOG = "/opt/zeek/spool/zeek/conn.log"
+
+LOCAL_LOGS_DIR = os.path.join(os.path.dirname(__file__), "..", "logs")
+LOCAL_EVE_JSON = os.path.join(LOCAL_LOGS_DIR, "eve.json")
+LOCAL_CONN_LOG = os.path.join(LOCAL_LOGS_DIR, "conn.log")
+
+POLL_INTERVAL_SECONDS = 15
+
+# Tracks the last-seen remote file size per path, across polls, so we can
+# skip re-downloading a file that hasn't changed.
+_last_sizes = {}
+
+
+def _connect():
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    client.connect(
+        hostname=HONEYPOT_HOST,
+        username=HONEYPOT_USER,
+        key_filename=HONEYPOT_KEY_PATH,
+        timeout=10,
+    )
+    return client
+
+
+def _sync_once(sftp):
+    os.makedirs(LOCAL_LOGS_DIR, exist_ok=True)
+
+    for remote_path, local_path in (
+        (REMOTE_EVE_JSON, LOCAL_EVE_JSON),
+        (REMOTE_CONN_LOG, LOCAL_CONN_LOG),
+    ):
+        try:
+            remote_size = sftp.stat(remote_path).st_size
+        except FileNotFoundError:
+            print(f"[honeypot_log_sync] remote file not found yet: {remote_path}")
+            continue
+        except Exception as e:
+            print(f"[honeypot_log_sync] stat failed for {remote_path}: {e}")
+            continue
+
+        if _last_sizes.get(remote_path) == remote_size:
+            continue  # unchanged since last poll -- skip transfer
+
+        try:
+            sftp.get(remote_path, local_path)
+            _last_sizes[remote_path] = remote_size
+            print(f"[honeypot_log_sync] pulled {os.path.basename(remote_path)} ({remote_size} bytes)")
+        except Exception as e:
+            print(f"[honeypot_log_sync] transfer failed for {remote_path}: {e}")
+
+
+def _run_loop():
+    client = None
+    sftp = None
+    while True:
+        try:
+            if client is None:
+                client = _connect()
+                sftp = client.open_sftp()
+                print(f"[honeypot_log_sync] connected to {HONEYPOT_HOST}")
+            _sync_once(sftp)
+        except Exception as e:
+            print(f"[honeypot_log_sync] connection error: {e} -- reconnecting next cycle")
+            try:
+                if client:
+                    client.close()
+            except Exception:
+                pass
+            client = None
+            sftp = None
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def start_background_sync():
+    """Call once from app.py at Flask startup to run the sync as a daemon thread."""
+    thread = threading.Thread(target=_run_loop, daemon=True, name="honeypot-log-sync")
+    thread.start()
+    print(f"[honeypot_log_sync] started -- polling {HONEYPOT_HOST} every {POLL_INTERVAL_SECONDS}s")
+    return thread
+
+
+if __name__ == "__main__":
+    # Standalone test mode: run the loop directly (blocking) so you can watch
+    # it work before wiring it into Flask.
+    print("[honeypot_log_sync] standalone mode -- Ctrl+C to stop")
+    _run_loop()

--- a/ai/ollama_embeddings.py
+++ b/ai/ollama_embeddings.py
@@ -1,0 +1,44 @@
+"""
+Direct Ollama embeddings, bypassing langchain_ollama.OllamaEmbeddings.
+
+On this machine, langchain_ollama.OllamaEmbeddings was not honoring an
+explicit base_url argument -- it kept targeting a stray, non-standard local
+port instead of 127.0.0.1:11434, regardless of what was passed in or what
+OLLAMA_HOST was set to. Confirmed by testing the underlying `ollama` package
+directly with an explicit host, which worked correctly every time.
+
+This wraps that same direct, working call in LangChain's Embeddings
+interface, so it's a drop-in replacement for OllamaEmbeddings anywhere it
+was used (rag_setup.py's indexing step, app.py's live retriever).
+"""
+
+import ollama
+from langchain_core.embeddings import Embeddings
+
+
+class DirectOllamaEmbeddings(Embeddings):
+    def __init__(self, model: str = "nomic-embed-text", host: str = "http://127.0.0.1:11434"):
+        self.model = model
+        self.client = ollama.Client(host=host)
+
+    def embed_documents(self, texts, batch_size: int = 100):
+        # A single huge batch (thousands of texts in one call) was crashing
+        # something inside the ollama package -- but a single string worked
+        # fine in isolation. Splitting into modest-sized batches is a middle
+        # ground: far fewer round trips than one-at-a-time, while staying
+        # small enough to (hopefully) avoid whatever the large-batch path
+        # was triggering. If this still fails, drop batch_size further
+        # (e.g. 5) before falling back to one-at-a-time.
+        results = []
+        total = len(texts)
+        for start in range(0, total, batch_size):
+            chunk = texts[start:start + batch_size]
+            result = self.client.embed(model=self.model, input=chunk)
+            results.extend(result["embeddings"])
+            done = min(start + batch_size, total)
+            print(f"[ollama_embeddings] embedded {done}/{total}")
+        return results
+
+    def embed_query(self, text):
+        result = self.client.embed(model=self.model, input=text)
+        return result["embeddings"][0]

--- a/ai/rag_setup.py
+++ b/ai/rag_setup.py
@@ -1,12 +1,26 @@
+import os
+
+# Set BEFORE any langchain_ollama/ollama imports -- if any part of that import
+# chain reads OLLAMA_HOST at import time rather than fresh on every call, an
+# override placed after the import (as this used to be) arrives too late and
+# whatever the system/Ollama desktop app had already set (observed: a
+# different random port on every run) wins instead.
+os.environ['OLLAMA_HOST'] = 'http://127.0.0.1:11434'
+
 import datetime
 import json
 import shutil
-import os
 import argparse
 from langchain_chroma import Chroma
-from langchain_ollama import OllamaEmbeddings
 from langchain_core.documents import Document
-os.environ['OLLAMA_HOST'] = 'http://127.0.0.1:11434'
+from ollama_embeddings import DirectOllamaEmbeddings
+
+# The single source of truth for where Ollama actually lives. Passed
+# explicitly to OllamaEmbeddings below (not just left to the env var) so the
+# connection can't be silently hijacked by anything else on the system that
+# also sets OLLAMA_HOST -- explicit constructor args are evaluated fresh at
+# call time, not cached at import time.
+OLLAMA_BASE_URL = "http://127.0.0.1:11434"
 
 # ── CONFIG ──────────────────────────────────────────────────────────────────
 USEFUL_TYPES = {"alert", "dns", "http", "tls", "flow"}
@@ -170,8 +184,8 @@ print("\nSample chunk:")
 print(docs[0].page_content)
 print()
 
-print("Building ChromaDB...")
-embeddings  = OllamaEmbeddings(model="nomic-embed-text")
+print(f"Building ChromaDB (Ollama at {OLLAMA_BASE_URL})...")
+embeddings  = DirectOllamaEmbeddings(model="nomic-embed-text", host=OLLAMA_BASE_URL)
 vectorstore = Chroma.from_documents(
     docs,
     embeddings,

--- a/web/app.py
+++ b/web/app.py
@@ -5,11 +5,10 @@ from flask_bcrypt import Bcrypt
 from langchain_ollama import OllamaLLM
 from langchain_groq import ChatGroq
 from langchain_google_genai import ChatGoogleGenerativeAI
-from langchain_ollama import OllamaEmbeddings
 from langchain_chroma import Chroma
 from langchain_mistralai import ChatMistralAI
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import datetime
 import sqlite3
 import json
 import os
@@ -101,7 +100,13 @@ def init_db():
 init_db()
 # ─────────────────────────────────────────────────────────────────────────────
 
-embeddings = OllamaEmbeddings(model="nomic-embed-text")
+# langchain_ollama.OllamaEmbeddings was not honoring an explicit base_url on
+# this machine -- it kept targeting a stray non-standard local port instead
+# of 127.0.0.1:11434 regardless of what was passed in. DirectOllamaEmbeddings
+# bypasses it and talks to the ollama package directly (confirmed working).
+from ai.ollama_embeddings import DirectOllamaEmbeddings
+
+embeddings = DirectOllamaEmbeddings(model="nomic-embed-text", host="http://127.0.0.1:11434")
 
 vectorstore = Chroma(
     persist_directory="../ai/chroma_db",
@@ -474,8 +479,7 @@ Answer naturally. Pick the format that fits. Do not force sections that do not a
 @app.route('/logs', methods=['GET'])
 def get_logs():
     logs = load_logs()
-    limit = min(int(request.args.get('limit', 50)), 1000)
-    return jsonify(logs[:limit])
+    return jsonify(logs[:50])
 
 
 @app.route('/models', methods=['GET'])
@@ -560,8 +564,6 @@ def health():
 def search():
     query  = request.args.get('q', '').strip()
     event_type = request.args.get('type', None)
-    offset = int(request.args.get('offset', 0))
-    limit  = min(int(request.args.get('limit', 100)), 500)
     logs  = load_logs()
 
     if query:
@@ -572,12 +574,7 @@ def search():
     if event_type:
         logs = [l for l in logs if l.get('event_type') == event_type]
 
-    return jsonify({
-        "results": logs[offset:offset+limit],
-        "total": len(logs),
-        "offset": offset,
-        "limit": limit,
-    })
+    return jsonify(logs[:100])  # return top 100 matches
 
 
 @app.route('/timeline', methods=['GET'])
@@ -596,8 +593,6 @@ def timeline():
 @app.route('/top-ips', methods=['GET'])
 def top_ips():
     logs = load_logs()
-    hours = request.args.get('hours', type=int)
-    logs = _filter_by_hours(logs, hours)
     limit = int(request.args.get('limit', 10))
     ip_counts = Counter(l.get('src_ip') for l in logs if l.get('src_ip'))
     result = [{"ip": ip, "count": count} for ip, count in ip_counts.most_common(limit)]
@@ -1314,25 +1309,8 @@ def _log_date_hour(ts):
     return m.group(1), int(m.group(2))
 
 
-def _parse_full_ts(ts):
-    """Parse a Suricata ISO timestamp into a naive UTC datetime, or None."""
-    try:
-        return datetime.strptime((ts or "")[:19], "%Y-%m-%dT%H:%M:%S")
-    except ValueError:
-        return None
-
-
-def _filter_by_hours(logs, hours):
-    """Keep only logs within the last `hours` hours. hours=None/0 = no filtering (all time)."""
-    if not hours:
-        return logs
-    cutoff = datetime.utcnow() - timedelta(hours=hours)
-    return [l for l in logs if (dt := _parse_full_ts(l.get('timestamp'))) and dt >= cutoff]
-
-
-def _compliance_context(hours=None):
+def _compliance_context():
     logs = load_logs()
-    logs = _filter_by_hours(logs, hours)
     total_events = len(logs)
     alert_events = [l for l in logs if l.get('event_type') == 'alert']
     alert_count = len(alert_events)
@@ -1435,8 +1413,7 @@ def _evaluate_controls(ctx):
 
 @app.route('/compliance/overview', methods=['GET'])
 def compliance_overview():
-    hours = request.args.get('hours', type=int)
-    ctx = _compliance_context(hours)
+    ctx = _compliance_context()
     controls = _evaluate_controls(ctx)
     weight = {"pass": 1, "warn": 0.5, "fail": 0}
 
@@ -1466,17 +1443,14 @@ def compliance_overview():
 
 @app.route('/compliance/controls', methods=['GET'])
 def compliance_controls():
-    hours = request.args.get('hours', type=int)
-    ctx = _compliance_context(hours)
+    ctx = _compliance_context()
     return jsonify(_evaluate_controls(ctx))
 
 
 @app.route('/compliance/findings', methods=['GET'])
 def compliance_findings():
     limit = min(int(request.args.get('limit', 10)), 200)
-    hours = request.args.get('hours', type=int)
     logs = load_logs()
-    logs = _filter_by_hours(logs, hours)
     alerts = [l for l in logs if l.get('event_type') == 'alert']
     alerts.sort(key=lambda l: l.get('timestamp', ''), reverse=True)
 
@@ -1499,9 +1473,7 @@ def compliance_findings():
 
 @app.route('/compliance/heatmap', methods=['GET'])
 def compliance_heatmap():
-    hours = request.args.get('hours', type=int)
     logs = load_logs()
-    logs = _filter_by_hours(logs, hours)
     grid = Counter()
     for l in logs:
         if l.get('event_type') != 'alert':
@@ -1521,9 +1493,7 @@ def compliance_heatmap():
 
 @app.route('/compliance/trend', methods=['GET'])
 def compliance_trend():
-    hours = request.args.get('hours', type=int)
     logs = load_logs()
-    logs = _filter_by_hours(logs, hours)
     by_day = {}
     for l in logs:
         date_str, _ = _log_date_hour(l.get('timestamp'))
@@ -1544,4 +1514,30 @@ def compliance_trend():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True, port=5000)
+    # Pull Suricata/Zeek logs from the public honeypot VM automatically,
+    # instead of manually uploading eve.json/conn.log. WERKZEUG_RUN_MAIN is
+    # only set in the child process the debug reloader actually forks to
+    # serve requests -- checking it here (rather than starting unconditionally)
+    # stops the sync thread from being started twice (once in the reloader's
+    # parent watcher process, once in the child) when debug=True.
+    if os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
+        from ai.honeypot_log_sync import start_background_sync
+        start_background_sync()
+
+    # NOTE: debug=True's reloader watches every .py file under the project
+    # tree recursively, including web/Wav2Lip/. When /sira-face-speak runs
+    # inference (which touches files inside face_detection/detection/sfd/),
+    # the reloader saw that as "code changed" and killed + restarted the
+    # whole Flask process mid-request -> browser saw it as a CORS failure
+    # (connection reset, no headers ever sent), not a real error.
+    # exclude_patterns keeps the reloader watching your actual app code
+    # while ignoring the Wav2Lip subdirectory entirely.
+    app.run(
+        host='0.0.0.0',
+        debug=True,
+        port=5000,
+        exclude_patterns=[
+            "*/Wav2Lip/*",
+            "*\\Wav2Lip\\*",
+        ],
+    )


### PR DESCRIPTION
SC-65: Automated honeypot log sync + Ollama embeddings/Hermes grounding fixes

Honeypot infrastructure
- Provisioned sira-honeypot VM on Azure (B2ls_v2, Australia East, resource group soc-copilot)
- Installed Suricata (52k+ ET Open rules) and Zeek 8.0.9, both running and writing real logs
- Fixed SFTP read permissions (sirauser added to suricata + zeek groups)
- Built ai/honeypot_log_sync.py — SFTP daemon polling the honeypot every 15s, pulling eve.json/conn.log only on size change
- Wired sync into app.py as a background thread on Flask startup, guarded against double-start under the debug reloader

Ollama embeddings bug (ai/ollama_embeddings.py, new)
- langchain_ollama.OllamaEmbeddings was silently ignoring explicit base_url/OLLAMA_HOST and connecting to a stray local port every time, causing ChromaDB rebuilds to fail
- Replaced with DirectOllamaEmbeddings, a thin wrapper around the raw ollama package (confirmed working via isolated test)
- Batches embed calls (100 docs/request) instead of one huge batch, which was crashing on large inputs
- Applied in both ai/rag_setup.py (indexing) and web/app.py (live retriever) so the same fix covers indexing and query time

rag_setup.py
- OLLAMA_HOST now set before any langchain imports (was previously set too late to reliably take effect)
- Switched to DirectOllamaEmbeddings

hermes_agent.py — grounding fixes
- Removed hardcoded fallback IP (185.220.101.45) that was fed to every tool as a fake investigation target whenever no IP was named in the task
- Target IP is now picked dynamically from real top-IPs data, excluding private/RFC1918 and known cloud platform IPs (Azure wireserver/IMDS) -- falls back to an honest "no external attacker found" instead of inventing a target
- CVE lookup now searches using a real detected alert signature for the target IP, instead of a hardcoded generic phrase that was surfacing unrelated CVEs
- Added explicit grounding rules to the report-generation prompt: never invent IPs/CVEs not in the tool results, never describe internal/platform IP traffic as an attack

Still open
- ChromaDB rebuild not yet confirmed to complete end-to-end with the batched fix
- Hermes report not yet re-tested against the fixed agent
- Sentinel machine data still not wired into SIRA/Hermes retrieval
- Cowrie not yet installed on the honeypot VM