### PR TITLE
Fixed the eslint warning

### DIFF
--- a/web-react/src/App.js
+++ b/web-react/src/App.js
@@ -421,7 +421,7 @@ function SiraMessage({ text, modelChip }) {
     const startIdx = text.indexOf(current);
     if (startIdx === -1) continue;
     const endIdx = next ? text.indexOf(next) : text.length;
-    sections[current] = text.slice(startIdx + current.length, endIdx !== -1 ? endIdx : undefined).replace(/^[\s:\-]+/, "").trim();
+    sections[current] = text.slice(startIdx + current.length, endIdx !== -1 ? endIdx : undefined).replace(/^[\s:-]+/, "").trim();
   }
   const riskText = sections["RISK ASSESSMENT"] || "";
   const riskLevel = /CRITICAL/i.test(riskText) ? "critical" : /HIGH/i.test(riskText) ? "high" : /MEDIUM/i.test(riskText) ? "medium" : /LOW/i.test(riskText) ? "low" : "medium";

--- a/web-react/src/HermesDocuments.jsx
+++ b/web-react/src/HermesDocuments.jsx
@@ -97,7 +97,7 @@ function parseReport(text) {
   found.forEach((s, i) => {
     const start = s.idx + s.name.length;
     const end = i + 1 < found.length ? found[i + 1].idx : text.length;
-    const body = text.slice(start, end).replace(/^[\s:\-]+/, "").trim();
+    const body = text.slice(start, end).replace(/^[\s:-]+/, "").trim();
     if (body) sections.push({ name: s.name, body });
   });
   return sections;

--- a/web-react/src/HermesPage.jsx
+++ b/web-react/src/HermesPage.jsx
@@ -63,7 +63,7 @@ function parseHermesReport(text) {
     const start = text.indexOf(cur);
     if (start === -1) continue;
     const end = next ? text.indexOf(next) : text.length;
-    sections[cur] = text.slice(start + cur.length, end !== -1 ? end : undefined).replace(/^[\s:\-]+/, "").trim();
+    sections[cur] = text.slice(start + cur.length, end !== -1 ? end : undefined).replace(/^[\s:-]+/, "").trim();
   }
   return sections;
 }

--- a/web-react/src/History.js
+++ b/web-react/src/History.js
@@ -6,7 +6,6 @@ import {
   where,
   orderBy,
   getDocs,
-  deleteDoc,
   doc,
   writeBatch,
 } from "firebase/firestore";
@@ -58,7 +57,7 @@ function parseSiraResponse(text) {
     if (startIdx === -1) continue;
     const contentStart = startIdx + current.length + 1;
     const endIdx = next ? text.indexOf(next + ":") : text.length;
-    const content = text.slice(contentStart, endIdx !== -1 ? endIdx : undefined).replace(/^[\s\-]+/, "").trim();
+    const content = text.slice(contentStart, endIdx !== -1 ? endIdx : undefined).replace(/^[\s-]+/, "").trim();
     result.push({ heading: current, content });
   }
   return result.length > 0 ? result : null;

--- a/web-react/src/LandingPage.js
+++ b/web-react/src/LandingPage.js
@@ -1,7 +1,6 @@
 import { useRef, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion, useScroll, useSpring, useTransform } from "framer-motion";
-import FAQ from "./Faq";
 import { SplineScene } from "./components/ui/splite";
 
 const fadeUp = {

--- a/web-react/src/Soc2Dashboard.js
+++ b/web-react/src/Soc2Dashboard.js
@@ -21,13 +21,6 @@ const RANGE_OPTIONS = [
   { key: "all", label: "All time", hours: null },
 ];
 
-/* Color communicates status only — never decoration. Same 3-state scale everywhere. */
-function statusColor(score) {
-  if (score >= 80) return "var(--green)";
-  if (score > 0) return "var(--orange)";
-  return "var(--red)";
-}
-
 function timeAgo(iso) {
   if (!iso) return null;
   const diffMs = Date.now() - new Date(iso).getTime();


### PR DESCRIPTION
Fixes the 8 ESLint warnings that were being bypassed with CI=false:

- Removed unnecessary `\-` escapes in regex character classes (App.js, HermesDocuments.jsx, HermesPage.jsx, History.js) — a hyphen at the end of a character class is already literal
- Removed unused imports/variables: `deleteDoc` (History.js), `FAQ` (LandingPage.js — line 486 is just button text, the actual route is in index.js), `statusColor` (Soc2Dashboard.js), `useNavigate` (index.js)

Verified each "unused" symbol was genuinely unreferenced before removing — `statusColor` and `deleteDoc` also appear in SiraAvatar.js/SiraVoice.js/HermesDocuments.jsx, but those are separate local declarations that are actively used, so they were left alone.

`npm run build` compiles clean, so `CI=false` can be dropped.